### PR TITLE
PR 481 redone

### DIFF
--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -2374,8 +2374,7 @@ static void Modify_Frameskip(GSimpleAction *action, GVariant *parameter, gpointe
         Frameskip = autoFrameskipMax;
     }
     char buf[255];
-    memset(buf, 0, 255);
-    sprintf(buf, "Frameskip value is set to %s", string);
+    snprintf(buf, sizeof buf, "Frameskip value is set to %s", string);
     driver->AddLine(buf);
     g_simple_action_set_state(action, parameter);
 }

--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -2373,6 +2373,11 @@ static void Modify_Frameskip(GSimpleAction *action, GVariant *parameter, gpointe
     if (!autoframeskip) {
         Frameskip = autoFrameskipMax;
     }
+    char buf[255];
+    memset(buf, 0, 255);
+    sprintf(buf, "Frameskip value is set to %s", string);
+    driver->AddLine(buf);
+    g_simple_action_set_state(action, parameter);
 }
 
 /////////////////////////////// TOOLS MANAGEMENT ///////////////////////////////


### PR DESCRIPTION
PR #481 is a bit messed up, it re-adds a commit that's already merged (the first one), then adds a merge-commit undoing that commit. merging it as-is would cause hick-ups with tools that automatically process git history.
i cherry-picked the only commit that's good and put it into this new PR, plus added a fixup commit that removes the gratuitous memset, and uses the secure snprintf instead of sprintf.
whether the commit itself is reasonable is unknown, as i dont know whether in this context a stack-allocated buffer can be used, so it's probably best if the author of the GTK+3 port takes a look at it.

the steps i took for the cleaning up were:

```sh
git checkout master
git checkout -b pr481new
wget -c https://github.com/TASEmulators/desmume/pull/481/commits/61082687d12bb917263ce5003352a87c95441ba8.patch
git am 61082687d12bb917263ce5003352a87c95441ba8.patch
```