### PR TITLE
Pullreq/openal linux 01

### DIFF
--- a/desmume/src/frontend/posix/shared/mic_openal.cpp
+++ b/desmume/src/frontend/posix/shared/mic_openal.cpp
@@ -82,7 +82,7 @@ void Mic_Reset()
   if (!Mic_Inited)
     return;
 
-  memset(Mic_Buffer, 0, MIC_BUFSIZE*2*2);
+  memset(Mic_Buffer, 128, MIC_BUFSIZE*2*2);
   Mic_BufPos = 0;
   Mic_PlayBuf = 1;
   Mic_WriteBuf = 0;

--- a/desmume/src/frontend/posix/shared/mic_openal.cpp
+++ b/desmume/src/frontend/posix/shared/mic_openal.cpp
@@ -149,7 +149,17 @@ u8 Mic_ReadSample()
     stats_max = ret;
   if (ret < stats_min)
     stats_min = ret;
-  Mic_BufPos += 2;
+
+  // convert to 2 bytes to transfer over SPI
+  if (Mic_BufPos & 0x1)
+  {
+	  ret = ((ret & 0x01) << 7);
+  }
+  else
+  {
+	  ret = ((ret & 0xFE) >> 1);
+  }
+  Mic_BufPos += 1;
 
   return ret;
 }


### PR DESCRIPTION
    The data returned by Mic_ReadSample() must be transfered in 2 parts.
    This must be done by every microphone driver.
    
    I did test with Lunar: Dragon Song which values are considered loud,
    since you can run away by screaming/blowing into the microphone. Values
    from 33-223 don't trigger the escape, values from 0-32 and from 224-255
    trigger an escape attempt. Thus 128 would be considered silence.
