### PR TITLE
Linux: Fix recent entries with quote in filename

### DIFF
--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -3383,7 +3383,7 @@ common_gtk_main(GApplication *app, gpointer user_data)
         const char *name = gtk_recent_info_get_display_name(info);
         // TODO: Is that enough?  Maybe allocate instead?
         char action[1024];
-        sprintf(action, "app.recent('%s')", uri);
+        sprintf(action, "app.recent(\"%s\")", uri);
         g_menu_append(G_MENU(user_data), name, action);
 
         gtk_recent_info_unref(info);


### PR DESCRIPTION
According to RFC 2396, the single quote character (') is allowed in uri
strings and is not escaped by gtk, so the action string constructed for
the recent files menu must be quoted with " instead of '.

This fixes issue #437