### PR TITLE
Linux: Call NDS_Init() early

### DIFF
--- a/desmume/src/frontend/posix/gtk/desmume.cpp
+++ b/desmume/src/frontend/posix/gtk/desmume.cpp
@@ -32,8 +32,6 @@ BOOL click = FALSE;
 
 void desmume_init( int disable_sound)
 {
-	NDS_Init();
-	
 	if ( !disable_sound) {
 		SPU_ChangeSoundCore(SNDCORE_SDL, 735 * 4);
 	}

--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -3597,6 +3597,8 @@ int main (int argc, char *argv[])
   // The global menu screws up the window size...
   unsetenv("UBUNTU_MENUPROXY");
 
+  // this must be called as early as possible
+  NDS_Init();
 
   my_config.parse(argc, argv);
   init_configured_features( &my_config);


### PR DESCRIPTION
Since NDS_Init() takes no arguments, it should not hurt to call it early
in the gtk frontend, too.

This fixes the segfault in issue #415