### PR TITLE
CI: fix mac os interface build, to make everything green again

### DIFF
--- a/.github/workflows/build_interface.yml
+++ b/.github/workflows/build_interface.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install MacOS build deps
-        run: brew install coreutils gcc sdl2 meson
+        run: brew install coreutils gcc sdl2 meson glib
 
       - name: Build - Meson
         run: |


### PR DESCRIPTION
it's highly annoying to get the red X for any push or pull request
because mac os x interface build is broken since december.
fix it by installing glib which meson complains about.