### PR TITLE
Fix build action warning + use 64-bit build tools

### DIFF
--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup MSBuild.exe
-        uses: microsoft/setup-msbuild@v1.0.3
+        uses: microsoft/setup-msbuild@v1.1
         with:
           msbuild-architecture: x64
           vs-version: 16.1


### PR DESCRIPTION
When we were fiddling around trying to get the Windows build working in GitHub actions, the "setup-msbuild" action in the build job was set to v1.0.3. This version doesn't support the "msbuild-architecture" variable, which allows for use of the 64-bit build tools.

This PR changes to v1.1 of the action, which fixes the above and also gets rid of this warning in the build job:

![image](https://user-images.githubusercontent.com/18552155/156168474-b8aab79f-e053-49a1-af01-499d217e9ce9.png)

Sample run here: https://github.com/SimonAfek/desmume/actions/runs/1916084159