### PR TITLE
Fix register read/write hooks (potentially) using wrong integers sizes

### DIFF
--- a/desmume/src/frontend/interface/interface.cpp
+++ b/desmume/src/frontend/interface/interface.cpp
@@ -427,7 +427,7 @@ cpuToRegisterMaps [] =
 	{"", arm9PointerMap},
 };
 
-EXPORTED int desmume_memory_read_register(char* register_name)
+EXPORTED u32 desmume_memory_read_register(char* register_name)
 {
 	for(int cpu = 0; cpu < sizeof(cpuToRegisterMaps)/sizeof(*cpuToRegisterMaps); cpu++)
 	{
@@ -444,8 +444,8 @@ EXPORTED int desmume_memory_read_register(char* register_name)
 					switch(rpm.dataSize)
 					{ default:
 					case 1: return *(unsigned char*)rpm.pointer;
-					case 2: return *(unsigned short*)rpm.pointer;
-					case 4: return *(unsigned long*)rpm.pointer;
+					case 2: return *(u16*)rpm.pointer;
+					case 4: return *(u32*)rpm.pointer;
 					}
 				}
 			}
@@ -455,7 +455,7 @@ EXPORTED int desmume_memory_read_register(char* register_name)
 	return 0;
 }
 
-EXPORTED void desmume_memory_write_register(char* register_name, long value)
+EXPORTED void desmume_memory_write_register(char* register_name, u32 value)
 {
 	for(int cpu = 0; cpu < sizeof(cpuToRegisterMaps)/sizeof(*cpuToRegisterMaps); cpu++)
 	{
@@ -472,8 +472,8 @@ EXPORTED void desmume_memory_write_register(char* register_name, long value)
 					switch(rpm.dataSize)
 					{ default:
 					case 1: *(unsigned char*)rpm.pointer = (unsigned char)(value & 0xFF); break;
-					case 2: *(unsigned short*)rpm.pointer = (unsigned short)(value & 0xFFFF); break;
-					case 4: *(unsigned long*)rpm.pointer = value; break;
+					case 2: *(u16*)rpm.pointer = (u16)(value & 0xFFFF); break;
+					case 4: *(u32*)rpm.pointer = value; break;
 					}
 				}
 			}

--- a/desmume/src/frontend/interface/interface.h
+++ b/desmume/src/frontend/interface/interface.h
@@ -127,8 +127,8 @@ EXPORTED void desmume_memory_write_short(int address, unsigned short value);
 EXPORTED void desmume_memory_write_long(int address, unsigned long value);
 //EXPORTED void desmume_memory_write_byterange(int address, int length, const unsigned char *bytes);
 
-EXPORTED int desmume_memory_read_register(char* register_name);
-EXPORTED void desmume_memory_write_register(char* register_name, long value);
+EXPORTED u32 desmume_memory_read_register(char* register_name);
+EXPORTED void desmume_memory_write_register(char* register_name, u32 value);
 
 EXPORTED void desmume_memory_register_write(int address, int size, memory_cb_fnc cb);
 EXPORTED void desmume_memory_register_read(int address, int size, memory_cb_fnc cb);

--- a/desmume/src/lua-engine.cpp
+++ b/desmume/src/lua-engine.cpp
@@ -63,6 +63,7 @@
 #include "SPU.h"
 #include "saves.h"
 #include "emufile.h"
+#include "types.h"
 
 using namespace std;
 
@@ -2022,8 +2023,8 @@ DEFINE_LUA_FUNCTION(memory_getregister, "cpu_dot_registername_string")
 					switch(rpm.dataSize)
 					{ default:
 					case 1: lua_pushinteger(L, *(unsigned char*)rpm.pointer); break;
-					case 2: lua_pushinteger(L, *(unsigned short*)rpm.pointer); break;
-					case 4: lua_pushinteger(L, *(unsigned long*)rpm.pointer); break;
+					case 2: lua_pushinteger(L, *(u16*)rpm.pointer); break;
+					case 4: lua_pushinteger(L, *(u32*)rpm.pointer); break;
 					}
 					return 1;
 				}
@@ -2038,7 +2039,7 @@ DEFINE_LUA_FUNCTION(memory_getregister, "cpu_dot_registername_string")
 DEFINE_LUA_FUNCTION(memory_setregister, "cpu_dot_registername_string,value")
 {
 	const char* qualifiedRegisterName = luaL_checkstring(L,1);
-	unsigned long value = (unsigned long)(luaL_checkinteger(L,2));
+	unsigned long value = (u32)(luaL_checkinteger(L,2));
 	lua_settop(L,0);
 	for(int cpu = 0; cpu < sizeof(cpuToRegisterMaps)/sizeof(*cpuToRegisterMaps); cpu++)
 	{
@@ -2055,8 +2056,8 @@ DEFINE_LUA_FUNCTION(memory_setregister, "cpu_dot_registername_string,value")
 					switch(rpm.dataSize)
 					{ default:
 					case 1: *(unsigned char*)rpm.pointer = (unsigned char)(value & 0xFF); break;
-					case 2: *(unsigned short*)rpm.pointer = (unsigned short)(value & 0xFFFF); break;
-					case 4: *(unsigned long*)rpm.pointer = value; break;
+					case 2: *(u16*)rpm.pointer = (u16)(value & 0xFFFF); break;
+					case 4: *(u32*)rpm.pointer = value; break;
 					}
 					return 0;
 				}


### PR DESCRIPTION
I was going nuts today trying to figure out why writing the same value to a register just paniced the processor.

It seems the Lua interface and in result the interface frontend asume `unsigned long` to be 32bits, which it isn't neccesarily. I updated the types used to be the proper sized integers.