### PR TITLE
Interface: Fix memory leak on opening ROMs, added function to manually free ROMs

### DIFF
--- a/desmume/src/frontend/interface/interface.cpp
+++ b/desmume/src/frontend/interface/interface.cpp
@@ -39,6 +39,7 @@
 
 #define SCREENS_PIXEL_SIZE 98304
 volatile bool execute = false;
+volatile bool rom_opened = false;
 TieredRegion hooked_regions [HOOK_COUNT];
 std::map<unsigned int, memory_cb_fnc> hooks[HOOK_COUNT];
 
@@ -97,9 +98,21 @@ EXPORTED void desmume_set_language(u8 lang)
 EXPORTED int desmume_open(const char *filename)
 {
     int i;
+	if (rom_opened) {
+		NDS_FreeROM();
+	}
     clear_savestates();
     i = NDS_LoadROM(filename);
+	if (i > 0) {
+		rom_opened = true;
+	}
     return i;
+}
+
+EXPORTED void desmume_close()
+{
+	NDS_FreeROM();
+	rom_opened = false;
 }
 
 EXPORTED void desmume_set_savetype(int type) {

--- a/desmume/src/frontend/interface/interface.h
+++ b/desmume/src/frontend/interface/interface.h
@@ -71,7 +71,10 @@ EXPORTED void desmume_free(void);
 
 // 0 = Japanese, 1 = English, 2 = French, 3 = German, 4 = Italian, 5 = Spanish
 EXPORTED void desmume_set_language(u8 language);
+// Opens a new ROM, if a ROM was already opened, a new one is opened and the old was is automatically free'd.
 EXPORTED int desmume_open(const char *filename);
+// Frees and closes a ROM opened with desmume_open.
+EXPORTED void desmume_close();
 EXPORTED void desmume_set_savetype(int type);
 EXPORTED void desmume_pause(void);
 EXPORTED void desmume_resume(void);


### PR DESCRIPTION
As a side note, at a quick glance it seems that this also affects the Windows and Linux GUI frontends (didn't check Mac), since I couldn't find `NDS_FreeROM();` being called there when opening a new ROM. The Windows GUI only seems to free the old ROM when explicitly told to close the ROM. However this is only from a quick glance at the code, I didn't actually do more investigation, but it might be worth to check.
