### PR TITLE
Limit maximum number of backups files for load state backup

### DIFF
--- a/desmume/src/saves.cpp
+++ b/desmume/src/saves.cpp
@@ -765,19 +765,24 @@ void loadstate_slot(int num)
 				index_file = fopen(index_fname.c_str(), "w"); // Create if doesn't exist
 			}
 			
-			cur_index = (cur_index + 1) % max_index; // next
+			if (index_file) {
+				cur_index = (cur_index + 1) % max_index; // next
 
-			fprintf(index_file, "%d", cur_index); // Store new index
-			fprintf(index_file, "%d", EOF); // Avoid overwriting just most significant digits(e.g.: 1 -> 200 = 100 )
-			fclose(index_file);
+				fprintf(index_file, "%d", cur_index); // Store new index
+				fprintf(index_file, "%d", EOF); // Avoid overwriting just most significant digits(e.g.: 1 -> 200 = 100 )
+				fclose(index_file);
 
-			std::string fname = dirname + PSS;
-			char mini[100];
-			sprintf(mini,"%u", cur_index);
-			fname += mini + (std::string)".dst";
+				std::string fname = dirname + PSS;
+				char mini[100];
+				sprintf(mini, "%u", cur_index);
+				fname += mini + (std::string)".dst";
 
-			savestate_save(fname.c_str());
-			printf("Creating backup of current state prior to loadstate as path: %s\n",fname.c_str());
+				savestate_save(fname.c_str());
+				printf("Creating backup of current state prior to loadstate as path: %s\n", fname.c_str());
+			}
+			else {
+				printf("Failed to open indexing file %s\n Prior state backup not created, check location write permissions.\n", index_fname.c_str());
+			}
 			
 		}
 	}

--- a/desmume/src/saves.cpp
+++ b/desmume/src/saves.cpp
@@ -732,7 +732,11 @@ void loadstate_slot(int num)
 
 	//save the state before we load the state, to give people a path for recovery in case they hit the wrong key
 	#ifdef HOST_WINDOWS
-	if(!GetPrivateProfileInt("General", "BackupSavestateSuppress", 0, IniName))
+	// Maximum backup number can be set in config: [General] BackupSavesMax=<n>
+	// Setting BackupSavesMax=0 would disable backups
+	int max_index = GetPrivateProfileInt("General", "BackupSavesMax", -1, IniName); // 0 for disabled
+	int suppress_backups = GetPrivateProfileInt("General", "BackupSavestateSuppress", 0, IniName);
+	if(!suppress_backups && max_index != 0 )
 	#endif
 	{
 		if(movieMode == MOVIEMODE_INACTIVE)
@@ -746,7 +750,9 @@ void loadstate_slot(int num)
 			mkdir(dirname.c_str(),0777);
 			
 			int cur_index = -1; // setup index, -1 in case it is first instance
-			int max_index = 200; // Would be better to get from config instead of hardcodding
+			if (max_index == -1) { // If not set
+				max_index = 200;
+			}
 			
 			std::string index_fname = dirname + PSS + "backup.index";
 			FILE* index_file = fopen(index_fname.c_str(), "r+"); // Read/update but don't create

--- a/desmume/src/saves.cpp
+++ b/desmume/src/saves.cpp
@@ -746,7 +746,7 @@ void loadstate_slot(int num)
 			mkdir(dirname.c_str(),0777);
 			
 			int cur_index = -1; // setup index, -1 in case it is first instance
-			int max_index = 5; // Would be better to get from config instead of hardcodding
+			int max_index = 200; // Would be better to get from config instead of hardcodding
 			
 			std::string index_fname = dirname + PSS + "backup.index";
 			FILE* index_file = fopen(index_fname.c_str(), "r+"); // Read/update but don't create
@@ -762,6 +762,7 @@ void loadstate_slot(int num)
 			cur_index = (cur_index + 1) % max_index; // next
 
 			fprintf(index_file, "%d", cur_index); // Store new index
+			fprintf(index_file, "%d", EOF); // Avoid overwriting just most significant digits(e.g.: 1 -> 200 = 100 )
 			fclose(index_file);
 
 			std::string fname = dirname + PSS;


### PR DESCRIPTION
Keep only maximum of <n> (200 by default) backups when creating backup during state load.
Once maximum files exist overwrite oldest one.

Also added ability to define <n> in desmume.ini under [General] BackupSavesMax=<n>

Based on discussion in https://github.com/TASEmulators/desmume/issues/522