### PR TITLE
CI: add action to create release tarball

### DIFF
--- a/.github/workflows/release_tarball.yml
+++ b/.github/workflows/release_tarball.yml
@@ -1,0 +1,43 @@
+name: Generate Source Tarball
+
+# Trigger whenever a release is created
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: archive
+      id: archive
+      run: |
+        THISDIR="$PWD"
+        cd desmume/src/frontend/posix
+        autoreconf -i
+        cd "$THISDIR"
+        VERSION=$(printf "%s\n" ${{ github.event.release.tag_name }} | sed 's/^v//')
+        PKGNAME="desmume-$VERSION"
+        mkdir -p /tmp/$PKGNAME
+        mv * /tmp/$PKGNAME
+        mv /tmp/$PKGNAME .
+        TARBALL=$PKGNAME.tar.xz
+        tar cJf $TARBALL $PKGNAME
+        echo "::set-output name=tarball::$TARBALL"
+
+    - name: upload tarball
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./${{ steps.archive.outputs.tarball }}
+        asset_name: ${{ steps.archive.outputs.tarball }}
+        asset_content_type: application/x-xz

--- a/.github/workflows/release_tarball.yml
+++ b/.github/workflows/release_tarball.yml
@@ -23,7 +23,7 @@ jobs:
         cd desmume/src/frontend/posix
         autoreconf -i
         cd "$THISDIR"
-        VERSION=$(printf "%s\n" ${{ github.event.release.tag_name }} | sed 's/^v//')
+        VERSION=$(printf "%s\n" ${{ github.event.release.tag_name }} | sed -e 's/^release_//' -e 's/_/./g')
         PKGNAME="desmume-$VERSION"
         mkdir -p /tmp/$PKGNAME
         mv * /tmp/$PKGNAME


### PR DESCRIPTION
once a tag has been pushed and "draft new release" using that tag finalized, a source tarball will be automatically uploaded to that release, as can be seen here: https://github.com/rofl0r/desmume-gtk2/releases/tag/v9.99.91