### PR TITLE
Allow scanDir() to operate when fatDir is empty

### DIFF
--- a/desmume/src/slot1.cpp
+++ b/desmume/src/slot1.cpp
@@ -45,7 +45,7 @@ static std::string fatDir;
 
 static void scanDir()
 {
-	if(fatDir == "") return;
+	if(fatDir == "" && !slot1_R4_path_type) return;
 	
 	if (fatImage)
 	{


### PR DESCRIPTION
The only time we need fatDir to be not-empty is when we are using a custom FAT directory (ie. `slot1_R4_path_type/sameAsRom == false`). When we are using the ROM path (`slot1_R4_path_type/sameAsRom == true`), fatDir is not even used, and we should be able to load the FAT image.