### PR TITLE
Decide `hasSecureArea` from `DecryptSecureArea()`

### DIFF
--- a/desmume/src/NDSSystem.cpp
+++ b/desmume/src/NDSSystem.cpp
@@ -2478,19 +2478,24 @@ bool NDS_FakeBoot()
 
 	//since we're bypassing the code to decrypt the secure area, we need to make sure its decrypted first
 	//this has not been validated on big endian systems. it almost positively doesn't work.
+	bool hasSecureArea = false;
 	if (gameInfo.header.CRC16 != 0)
 	{
-		bool okRom = DecryptSecureArea((u8*)&gameInfo.header, (u8*)gameInfo.secureArea);
+		int okRom = DecryptSecureArea((u8*)&gameInfo.header, (u8*)gameInfo.secureArea);
 
-		if(!okRom) {
+		if(okRom == -1)
+		{
 			printf("Specified file is not a valid rom\n");
 			return false;
+		}
+		else if (okRom == 1)
+		{
+			hasSecureArea = true;
 		}
 	}
 	
 	//firmware loads the game card arm9 and arm7 programs as specified in rom header
 	{
-		bool hasSecureArea = ((gameInfo.romType == ROM_NDS) && (gameInfo.header.CRC16 != 0));
 		//copy the arm9 program to the address specified by rom header
 		u32 src = header->ARM9src;
 		u32 dst = header->ARM9cpy;

--- a/desmume/src/utils/decrypt/decrypt.cpp
+++ b/desmume/src/utils/decrypt/decrypt.cpp
@@ -488,7 +488,7 @@ static void encrypt_arm9(u32 cardheader_gamecode, unsigned char *data)
 //0x0200 - 0x3FFF : typically, nothing is stored here. on retail cards, you can't read from that area anyway, but im not sure if that's done in the game card or the GC bus controller on the system
 //0x4000 - 0x7FFF : secure area (details in gbatek)
 
-bool DecryptSecureArea(u8 *romheader, u8 *secure)
+int DecryptSecureArea(u8 *romheader, u8 *secure)
 {
 	//this looks like it will only work on little endian hosts
 	Header* header = (Header*)romheader;
@@ -496,12 +496,13 @@ bool DecryptSecureArea(u8 *romheader, u8 *secure)
 	int romType = DetectRomType(*header, (char*)secure);
 
 	if(romType == ROMTYPE_INVALID)
-		return false;
+		return -1;
 
 	// check if ROM is already encrypted
 	if (romType == ROMTYPE_NDSDUMPED)
 	{
 		printf("Already decrypted.\n");
+		return 1;
 	}
 	else if (romType >= ROMTYPE_ENCRSECURE)		// includes ROMTYPE_MASKROM
 	{
@@ -514,16 +515,16 @@ bool DecryptSecureArea(u8 *romheader, u8 *secure)
 		//memcpy(romdata+0x4000,data,0x800);
 
 		if (!decrypt_arm9(*(u32 *)header->gamecode, secure))
-			return false;
+			return -1;
 
 		printf("Decrypted.\n");
+		return 1;
 	}
 	else
 	{
 		printf("File doesn't appear to have a secure area.\n");
+		return 0;
 	}
-
-	return true;
 }
 
 bool EncryptSecureArea(u8 *romheader, u8 *secure)

--- a/desmume/src/utils/decrypt/decrypt.h
+++ b/desmume/src/utils/decrypt/decrypt.h
@@ -26,7 +26,8 @@
 extern const unsigned char arm7_key[];
 
 //decrypts the secure area of a rom (or does nothing if it is already decrypted)
-bool DecryptSecureArea(u8 *romheader, u8 *secure);
+//This function returns -1 on invalid ROM, 1 on successful decryption, or 0 when no secure area appears to exist
+int DecryptSecureArea(u8 *romheader, u8 *secure);
 
 //encrypts the secure area of a rom (or does nothing if it is already encrypted)
 bool EncryptSecureArea(u8 *romheader, u8 *secure);


### PR DESCRIPTION
This avoids some issues when loading homebrew that has CRC16 != 0.