### PR TITLE
Check `gameCode==####` for homebrew

### DIFF
--- a/desmume/src/NDSSystem.cpp
+++ b/desmume/src/NDSSystem.cpp
@@ -635,7 +635,8 @@ bool GameInfo::isDSiEnhanced()
 
 bool GameInfo::isHomebrew()
 {
-	return ((header.ARM9src < 0x4000) && (T1ReadLong(header.logo, 0) != 0x51AEFF24) && (T1ReadLong(header.logo, 4) != 0x699AA221));
+	return ((header.ARM9src < 0x4000) && (T1ReadLong(header.logo, 0) != 0x51AEFF24) && (T1ReadLong(header.logo, 4) != 0x699AA221)) ||
+	       (!memcmp(header.gameCode, "####", 4)); // <- ndstool default signature
 }
 
 static int rom_init_path(const char *filename, const char *physicalName, const char *logicalFilename)


### PR DESCRIPTION
As of a while ago (maybe since the start?), ndstool generates `gameCode = ####` in the ROM header. This is generally a very good sign that the application is homebrew, as commercial games do not use this character in their `gameCode`.