### PR TITLE
Fixed GBA SRAMPath in posix CLI

### DIFF
--- a/desmume/src/frontend/posix/cli/main.cpp
+++ b/desmume/src/frontend/posix/cli/main.cpp
@@ -388,11 +388,10 @@ int main(int argc, char ** argv) {
 
         //set the GBA rom and sav paths
         GBACartridge_RomPath = my_config.gbaslot_rom.c_str();
-        if(toupper(strright(GBACartridge_RomPath,4)) == ".GBA")
-          GBACartridge_SRAMPath = strright(GBACartridge_RomPath,4) + ".sav";
-        else
-          //what to do? lets just do the same thing for now
-          GBACartridge_SRAMPath = strright(GBACartridge_RomPath,4) + ".sav";
+        // finds the index of the file extension separator
+        int RomPath_ExtIdx = GBACartridge_RomPath.find_last_of(".");
+        // checks if file has extension, if so replaces extension with .sav for SRAM Path, otherwise append .sav
+        GBACartridge_SRAMPath = GBACartridge_RomPath.substr(0, RomPath_ExtIdx) + ".sav";
 
         // Check if the file exists and can be opened
         FILE * test = fopen(GBACartridge_RomPath.c_str(), "rb");


### PR DESCRIPTION
The proposed PR applies a minor fix to the Linux CLI frontend to correctly assign the GBA SRAMPath. The issue is detailed in #536 . Briefly, before the GBA SRAMPath would be assigned as `.gba.sav` whenever the GBA ROM Path ended in `.sav`. The new method ensures that if a GBA ROM has path `gamerom.gba` the SRAM path will become `gamerom.sav`. Moreover, the proposed changes also allow for different file extensions of the GBA ROM and/or no file extension at all. 