### PR TITLE
Fix Keyboard Input bugs for Linux CLI and Interface

### DIFF
--- a/desmume/src/frontend/posix/shared/ctrlssdl.cpp
+++ b/desmume/src/frontend/posix/shared/ctrlssdl.cpp
@@ -513,7 +513,6 @@ process_ctrls_event( SDL_Event& event,
                 break;
             case SDLK_RSHIFT:
                 shift_pressed |= 2;
-                break;
             default:
                 key = lookup_key(event.key.keysym.sym);
                 ADD_KEY( cfg->keypad, key );

--- a/desmume/src/frontend/posix/shared/ctrlssdl.cpp
+++ b/desmume/src/frontend/posix/shared/ctrlssdl.cpp
@@ -30,7 +30,7 @@
 
 
 
-u16 keyboard_cfg[NB_KEYS];
+u32 keyboard_cfg[NB_KEYS];
 u16 joypad_cfg[NB_KEYS];
 u16 nbr_joy;
 mouse_status mouse;
@@ -171,7 +171,7 @@ u16 lookup_joy_key (u16 keyval) {
 }
 
 /* Return keypad vector with given key set to 1 */
-u16 lookup_key (u16 keyval) {
+u32 lookup_key (u32 keyval) {
   int i;
   u16 Key = 0;
 

--- a/desmume/src/frontend/posix/shared/ctrlssdl.cpp
+++ b/desmume/src/frontend/posix/shared/ctrlssdl.cpp
@@ -513,6 +513,7 @@ process_ctrls_event( SDL_Event& event,
                 break;
             case SDLK_RSHIFT:
                 shift_pressed |= 2;
+                /* fall-through */
             default:
                 key = lookup_key(event.key.keysym.sym);
                 ADD_KEY( cfg->keypad, key );

--- a/desmume/src/frontend/posix/shared/ctrlssdl.cpp
+++ b/desmume/src/frontend/posix/shared/ctrlssdl.cpp
@@ -507,18 +507,14 @@ process_ctrls_event( SDL_Event& event,
             break;
         }
 
-        switch(event.key.keysym.sym){
-            case SDLK_LSHIFT:
-                shift_pressed |= 1;
-                break;
-            case SDLK_RSHIFT:
-                shift_pressed |= 2;
-                /* fall-through */
-            default:
-                key = lookup_key(event.key.keysym.sym);
-                ADD_KEY( cfg->keypad, key );
-                break;
+        if (event.key.keysym.sym == SDLK_LSHIFT) {
+            shift_pressed |= 1;
+        } else if (event.key.keysym.sym == SDLK_RSHIFT) {
+            shift_pressed |= 2;
         }
+
+        key = lookup_key(event.key.keysym.sym);
+        ADD_KEY( cfg->keypad, key );
         break;
 
       case SDL_KEYUP:

--- a/desmume/src/frontend/posix/shared/ctrlssdl.h
+++ b/desmume/src/frontend/posix/shared/ctrlssdl.h
@@ -64,7 +64,7 @@
 /* Keypad key names */
 extern const char *key_names[NB_KEYS];
 /* Current keyboard configuration */
-extern u16 keyboard_cfg[NB_KEYS];
+extern u32 keyboard_cfg[NB_KEYS];
 /* Current joypad configuration */
 extern u16 joypad_cfg[NB_KEYS];
 /* Number of detected joypads */
@@ -103,7 +103,7 @@ u16 get_joy_key(int index);
 u16 get_set_joy_key(int index);
 void update_keypad(u16 keys);
 u16 get_keypad( void);
-u16 lookup_key (u16 keyval);
+u32 lookup_key (u32 keyval);
 u16 lookup_joy_key (u16 keyval);
 void
 process_ctrls_event( SDL_Event& event,


### PR DESCRIPTION
This fixes two bugs related to keyboard input for the Linux CLI build, which also fixes them for the Interface build since they make use of the same input code.

1. Allow most of the keyboard input bindings to actually work, by changing the `keyboard_cfg` array and the `lookup_key` function to use `u32`s rather than `u16`s, aligning them with the other keyboard input code. This was a problem because the input configuration is set with a `memcpy` from the default configuration which is a `u32[]` into the `keyboard_cfg` array, resulting in a mangled configuration as extra bytes were added, later keys were missing, and some key codes that require 32 bits were split and therefore invalid.
2. Allow a `KEYDOWN` event of the Right Shift key to both trigger a modifier as it used to, and also act to press an emulated button. This is needed as the default configuration is for Right Shift to be Select, but the switch statement that handled input never let a Right Shift event pass through to the emulated inputs. It is fixed simply by allowing a fall-through of that case into the default.