### PR TITLE
Remove "simple" SPU logic path

### DIFF
--- a/desmume/src/NDSSystem.h
+++ b/desmume/src/NDSSystem.h
@@ -531,7 +531,6 @@ extern struct TCommonSettings
 		, manualBackupType(0)
 		, autodetectBackupMethod(0)
 		, spu_captureMuted(false)
-		, spu_advanced(true)
 		, StylusPressure(50)
 		, ConsoleType(NDS_CONSOLE_TYPE_FAT)
 		, backupSave(false)
@@ -654,7 +653,6 @@ extern struct TCommonSettings
 
 	bool spu_muteChannels[16];
 	bool spu_captureMuted;
-	bool spu_advanced;
 
 	struct _ShowGpu {
 		_ShowGpu() : main(true), sub(true) {}

--- a/desmume/src/SPU.cpp
+++ b/desmume/src/SPU.cpp
@@ -1382,6 +1382,11 @@ FORCEINLINE static void _SPU_WriteCapture(SPU_struct::REGS::CAP& cap, const chan
 
 				if(runtime.curdad >= runtime.maxdad)
 				{
+					if(cap.oneshot)
+					{
+						cap.active = runtime.running = 0;
+						return;
+					}
 					runtime.curdad = cap.dad;
 					runtime.sampcntInt -= capLen_shifted;
 				}
@@ -1645,6 +1650,10 @@ static void SPU_MixAudio(bool actuallyMix, SPU_struct *SPU, int length)
 			else
 				_SPU_WriteCapture<16>(SPU->regs.cap[1], SPU->channels[3], capbuf+1, thisLength);
 		}
+
+		// Capture can end in one-shot mode, so update state when this happens
+		if(!SPU->regs.cap[0].runtime.running) cap0Src = CAPSRC_NONE, captureFlags &= ~(1<<0 | 1<<1);
+		if(!SPU->regs.cap[1].runtime.running) cap1Src = CAPSRC_NONE, captureFlags &= ~(1<<2 | 1<<3);
 
 		// Advance buffer
 		outbuf += thisLength*2;

--- a/desmume/src/commandline.cpp
+++ b/desmume/src/commandline.cpp
@@ -142,7 +142,6 @@ ENDL
 " --advanced-timing          Use advanced bus-level timing; default ON" ENDL
 " --rigorous-timing          Use more realistic component timings; default OFF" ENDL
 " --gamehacks                Use game-specific hacks; default ON" ENDL
-" --spu-advanced             Enable advanced SPU capture functions (reverb)" ENDL
 " --backupmem-db             Use DB for autodetecting backup memory type" ENDL
 ENDL
 "Arguments affecting the emulated requipment:" ENDL

--- a/desmume/src/commandline.cpp
+++ b/desmume/src/commandline.cpp
@@ -51,7 +51,6 @@ CommandLine::CommandLine()
 , _fw_boot(0)
 , _spu_sync_mode(-1)
 , _spu_sync_method(-1)
-, _spu_advanced(0)
 , _num_cores(-1)
 , _rigorous_timing(0)
 , _advanced_timing(-1)
@@ -283,7 +282,6 @@ bool CommandLine::parse(int argc,char **argv)
 			{ "rigorous-timing", no_argument, &_rigorous_timing, 1},
 			{ "advanced-timing", no_argument, &_advanced_timing, 1},
 			{ "gamehacks", no_argument, &_gamehacks, 1},
-			{ "spu-advanced", no_argument, &_spu_advanced, 1},
 			{ "backupmem-db", no_argument, &autodetect_method, 1},
 
 			//system equipment
@@ -458,7 +456,6 @@ bool CommandLine::parse(int argc,char **argv)
 	if(_slot1_no8000prot) CommonSettings.RetailCardProtection8000 = false;
 	if(_spu_sync_mode != -1) CommonSettings.SPU_sync_mode = _spu_sync_mode;
 	if(_spu_sync_method != -1) CommonSettings.SPU_sync_method = _spu_sync_method;
-	if(_spu_advanced) CommonSettings.spu_advanced = true;
 
 	free(_bios_arm9);
 	free(_bios_arm7);

--- a/desmume/src/commandline.h
+++ b/desmume/src/commandline.h
@@ -99,7 +99,6 @@ private:
 	int _fw_boot;
 	int _load_to_memory;
 	int _bios_swi;
-	int _spu_advanced;
 	int _num_cores;
 	int _rigorous_timing;
 	int _advanced_timing;

--- a/desmume/src/frontend/cocoa/DefaultUserPrefs.plist
+++ b/desmume/src/frontend/cocoa/DefaultUserPrefs.plist
@@ -942,8 +942,6 @@
 	<integer>58325</integer>
 	<key>Sound_Volume</key>
 	<integer>100</integer>
-	<key>SPU_AdvancedLogic</key>
-	<true/>
 	<key>SPU_InterpolationMode</key>
 	<integer>2</integer>
 	<key>SPU_SyncMethod</key>

--- a/desmume/src/frontend/cocoa/cocoa_output.h
+++ b/desmume/src/frontend/cocoa/cocoa_output.h
@@ -69,7 +69,6 @@ class ClientAVCaptureObject;
 	
 	apple_unfairlock_t _unfairlockAudioOutputEngine;
 	apple_unfairlock_t _unfairlockVolume;
-	apple_unfairlock_t _unfairlockSpuAdvancedLogic;
 	apple_unfairlock_t _unfairlockSpuInterpolationMode;
 	apple_unfairlock_t _unfairlockSpuSyncMode;
 	apple_unfairlock_t _unfairlockSpuSyncMethod;
@@ -83,8 +82,6 @@ class ClientAVCaptureObject;
 - (float) volume;
 - (void) setAudioOutputEngine:(NSInteger)methodID;
 - (NSInteger) audioOutputEngine;
-- (void) setSpuAdvancedLogic:(BOOL)state;
-- (BOOL) spuAdvancedLogic;
 - (void) setSpuInterpolationMode:(NSInteger)modeID;
 - (NSInteger) spuInterpolationMode;
 - (void) setSpuSyncMode:(NSInteger)modeID;

--- a/desmume/src/frontend/cocoa/cocoa_output.mm
+++ b/desmume/src/frontend/cocoa/cocoa_output.mm
@@ -209,7 +209,6 @@
 	
 	_unfairlockAudioOutputEngine = apple_unfairlock_create();
 	_unfairlockVolume = apple_unfairlock_create();
-	_unfairlockSpuAdvancedLogic = apple_unfairlock_create();
 	_unfairlockSpuInterpolationMode = apple_unfairlock_create();
 	_unfairlockSpuSyncMode = apple_unfairlock_create();
 	_unfairlockSpuSyncMethod = apple_unfairlock_create();
@@ -222,7 +221,6 @@
 	[property setValue:[NSNumber numberWithBool:NO] forKey:@"mute"];
 	[property setValue:[NSNumber numberWithInteger:0] forKey:@"filter"];
 	[property setValue:[NSNumber numberWithInteger:SNDCORE_DUMMY] forKey:@"audioOutputEngine"];
-	[property setValue:[NSNumber numberWithBool:NO] forKey:@"spuAdvancedLogic"];
 	[property setValue:[NSNumber numberWithInteger:SPUInterpolation_None] forKey:@"spuInterpolationMode"];
 	[property setValue:[NSNumber numberWithInteger:SPU_SYNC_MODE_DUAL_SYNC_ASYNC] forKey:@"spuSyncMode"];
 	[property setValue:[NSNumber numberWithInteger:SPU_SYNC_METHOD_N] forKey:@"spuSyncMethod"];
@@ -234,7 +232,6 @@
 {
 	apple_unfairlock_destroy(_unfairlockAudioOutputEngine);
 	apple_unfairlock_destroy(_unfairlockVolume);
-	apple_unfairlock_destroy(_unfairlockSpuAdvancedLogic);
 	apple_unfairlock_destroy(_unfairlockSpuInterpolationMode);
 	apple_unfairlock_destroy(_unfairlockSpuSyncMode);
 	apple_unfairlock_destroy(_unfairlockSpuSyncMethod);
@@ -316,26 +313,6 @@
 	apple_unfairlock_unlock(_unfairlockAudioOutputEngine);
 	
 	return methodID;
-}
-
-- (void) setSpuAdvancedLogic:(BOOL)state
-{
-	apple_unfairlock_lock(_unfairlockSpuAdvancedLogic);
-	[property setValue:[NSNumber numberWithBool:state] forKey:@"spuAdvancedLogic"];
-	apple_unfairlock_unlock(_unfairlockSpuAdvancedLogic);
-	
-	pthread_rwlock_wrlock(self.rwlockProducer);
-	CommonSettings.spu_advanced = state;
-	pthread_rwlock_unlock(self.rwlockProducer);
-}
-
-- (BOOL) spuAdvancedLogic
-{
-	apple_unfairlock_lock(_unfairlockSpuAdvancedLogic);
-	BOOL state = [(NSNumber *)[property valueForKey:@"spuAdvancedLogic"] boolValue];
-	apple_unfairlock_unlock(_unfairlockSpuAdvancedLogic);
-	
-	return state;
 }
 
 - (void) setSpuInterpolationMode:(NSInteger)modeID

--- a/desmume/src/frontend/cocoa/openemu/NDSGameCore.mm
+++ b/desmume/src/frontend/cocoa/openemu/NDSGameCore.mm
@@ -203,7 +203,6 @@ volatile bool execute = true;
 	[cdsFirmware applySettings];
 	
 	// Set up the sound core
-	CommonSettings.spu_advanced = true;
 	CommonSettings.spuInterpolationMode = SPUInterpolation_Cosine;
 	CommonSettings.SPU_sync_mode = SPU_SYNC_MODE_SYNCHRONOUS;
 	CommonSettings.SPU_sync_method = SPU_SYNC_METHOD_N;

--- a/desmume/src/frontend/cocoa/userinterface/EmuControllerDelegate.mm
+++ b/desmume/src/frontend/cocoa/userinterface/EmuControllerDelegate.mm
@@ -1199,7 +1199,6 @@
 	
 	[[NSUserDefaults standardUserDefaults] setFloat:[[speakerBindings valueForKey:@"volume"] floatValue] forKey:@"Sound_Volume"];
 	[[NSUserDefaults standardUserDefaults] setInteger:[[speakerBindings valueForKey:@"audioOutputEngine"] integerValue] forKey:@"Sound_AudioOutputEngine"];
-	[[NSUserDefaults standardUserDefaults] setBool:[[speakerBindings valueForKey:@"spuAdvancedLogic"] boolValue] forKey:@"SPU_AdvancedLogic"];
 	[[NSUserDefaults standardUserDefaults] setInteger:[[speakerBindings valueForKey:@"spuInterpolationMode"] integerValue] forKey:@"SPU_InterpolationMode"];
 	[[NSUserDefaults standardUserDefaults] setInteger:[[speakerBindings valueForKey:@"spuSyncMode"] integerValue] forKey:@"SPU_SyncMode"];
 	[[NSUserDefaults standardUserDefaults] setInteger:[[speakerBindings valueForKey:@"spuSyncMethod"] integerValue] forKey:@"SPU_SyncMethod"];
@@ -2609,7 +2608,6 @@
 	[self setCurrentVolumeValue:[[NSUserDefaults standardUserDefaults] floatForKey:@"Sound_Volume"]];
 	[[self cdsSpeaker] setVolume:[[NSUserDefaults standardUserDefaults] floatForKey:@"Sound_Volume"]];
 	[[self cdsSpeaker] setAudioOutputEngine:[[NSUserDefaults standardUserDefaults] integerForKey:@"Sound_AudioOutputEngine"]];
-	[[self cdsSpeaker] setSpuAdvancedLogic:[[NSUserDefaults standardUserDefaults] boolForKey:@"SPU_AdvancedLogic"]];
 	[[self cdsSpeaker] setSpuInterpolationMode:[[NSUserDefaults standardUserDefaults] integerForKey:@"SPU_InterpolationMode"]];
 	[[self cdsSpeaker] setSpuSyncMode:[[NSUserDefaults standardUserDefaults] integerForKey:@"SPU_SyncMode"]];
 	[[self cdsSpeaker] setSpuSyncMethod:[[NSUserDefaults standardUserDefaults] integerForKey:@"SPU_SyncMethod"]];

--- a/desmume/src/frontend/windows/main.cpp
+++ b/desmume/src/frontend/windows/main.cpp
@@ -2036,7 +2036,6 @@ int _main()
 	ScreenGapColor = GetPrivateProfileInt("Display", "ScreenGapColor", 0xFFFFFF, IniName);
 	CommonSettings.showGpu.main = GetPrivateProfileInt("Display", "MainGpu", 1, IniName) != 0;
 	CommonSettings.showGpu.sub = GetPrivateProfileInt("Display", "SubGpu", 1, IniName) != 0;
-	CommonSettings.spu_advanced = GetPrivateProfileBool("Sound", "SpuAdvanced", true, IniName);
 	CommonSettings.advanced_timing = GetPrivateProfileBool("Emulation", "AdvancedTiming", true, IniName);
 	CommonSettings.gamehacks.en = GetPrivateProfileBool("Emulation", "GameHacks", true, IniName);
 	CommonSettings.GFX3D_Renderer_TextureDeposterize =  GetPrivateProfileBool("3D", "TextureDeposterize", 0, IniName);
@@ -6546,9 +6545,6 @@ static LRESULT CALLBACK SoundSettingsDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam
 			SendDlgItemMessage(hDlg, IDC_SLVOLUME, TBM_SETPOS, TRUE, sndvolume);
 			SoundSettings_updateVolumeReadout(hDlg);
 
-			// Set spu advanced
-			CheckDlgItem(hDlg,IDC_SPU_ADVANCED,CommonSettings.spu_advanced);
-
 			timerid = SetTimer(hDlg, 1, 500, NULL);
 			return TRUE;
 		}
@@ -6624,10 +6620,6 @@ static LRESULT CALLBACK SoundSettingsDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam
 					//write interpolation type
 					CommonSettings.spuInterpolationMode = (SPUInterpolationMode)SendDlgItemMessage(hDlg, IDC_SPU_INTERPOLATION_CB, CB_GETCURSEL, 0, 0);
 					WritePrivateProfileInt("Sound","SPUInterpolation",(int)CommonSettings.spuInterpolationMode, IniName);
-
-					//write spu advanced
-					CommonSettings.spu_advanced = IsDlgCheckboxChecked(hDlg,IDC_SPU_ADVANCED);
-					WritePrivateProfileBool("Sound","SpuAdvanced",CommonSettings.spu_advanced,IniName);
 
 					return TRUE;
 				}

--- a/desmume/src/frontend/windows/resources.rc
+++ b/desmume/src/frontend/windows/resources.rc
@@ -1104,10 +1104,6 @@ BEGIN
     LTEXT           "Different ways to handle too-slow or too-fast",IDC_STATIC,24,138,138,8
     LTEXT           "in synch mode. Hopefully these will improve.",IDC_STATIC,24,146,139,8
     LTEXT           "Synchronous is more 'accurate' but you may prefer the sound of dual mode if you are running far from 60fps.  Beware that dual mode can clip the ends of sound effects and one-shot instruments.",IDC_STATIC,18,39,158,34
-    CONTROL         "Advanced SPU Logic (reboot game after changing)",IDC_SPU_ADVANCED,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,197,74,177,10
-    LTEXT           "This will be necessary to emulate sound capture (reverb and music visualization). This is costly, few games use it, and the effect is unnecessary.  Enable it if your system has power to spare; check the Sound Viewer to see if the game is using capture.",IDC_STATIC,196,86,177,41
-    LTEXT           "Can cause deterministically visible changes to emulation in principle!!!",IDC_STATIC,196,127,177,17
 END
 
 IDD_SOUND_VIEW DIALOGEX 0, 0, 568, 269


### PR DESCRIPTION
These commits remove the "simple" SPU logic path, and instead optimize the "advanced" path to hopefully achieve the same level of performance. (There is also a fix for an extremely obscure capture unit bug that I unintentionally pushed to the branch I was working on).

For the most part, performance appears to be mostly on-par with the original "simple" path. And since it doesn't appear to be performing much worse, I would say it's good enough to be able to remove the "simple" logic altogether.

I've tried my best to remove references to the logic mode toggle, but I believe the macOS version still needs further editing (I don't have a Mac to test/work on). So I'm creating this as a draft PR, so that if it seems worthwhile to merge the changes, further changes can be made.