### PR TITLE
CI: add build job for linux/GTK2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,24 @@ jobs:
       - name: ninja
         run: ninja -C desmume/src/frontend/posix/build
 
+  build_gtk2:
+    name: Build DeSmuME (Linux/GTK+2)
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: install dependencies
+        run: sudo apt update && sudo apt install autoconf libglu1-mesa-dev libsdl2-dev libpcap-dev libgtk2.0-dev
+
+      - name: buildit
+        run: |
+          cd desmume/src/frontend/posix/
+          autoreconf -i
+          ./configure --prefix=/usr --enable-gdb-stub --enable-wifi
+          make -j
+
   build_macos:
     name: Build DeSmuME (macOS)
     runs-on: macOS-11

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,18 @@ jobs:
           autoreconf -i
           ./configure --prefix=/usr --enable-gdb-stub --enable-wifi
           make -j
+          make DESTDIR=/tmp/DeSmuME install
+
+      - name: Pack artifact
+        run: |
+          cd /tmp
+          tar cJf DeSmuME.tar.xz DeSmuME/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: desmume-linux-gtk2-cli-x86_64
+          path: /tmp/DeSmuME.tar.xz
 
   build_macos:
     name: Build DeSmuME (macOS)


### PR DESCRIPTION
this makes sure the build of cli/gtk2 frontend doesnt break, and also serves as some sort of documentation for the build process on ubuntu.