### PR TITLE
posix: properly fix size mismatch of keyboard/joystick_cfg arrays

### DIFF
--- a/desmume/src/frontend/posix/shared/ctrlssdl.cpp
+++ b/desmume/src/frontend/posix/shared/ctrlssdl.cpp
@@ -31,7 +31,10 @@
 
 
 u32 keyboard_cfg[NB_KEYS];
-u16 joypad_cfg[NB_KEYS];
+u32 joypad_cfg[NB_KEYS];
+
+static_assert(sizeof(keyboard_cfg) == sizeof(joypad_cfg), "");
+
 u16 nbr_joy;
 mouse_status mouse;
 static int fullscreen;

--- a/desmume/src/frontend/posix/shared/ctrlssdl.h
+++ b/desmume/src/frontend/posix/shared/ctrlssdl.h
@@ -66,7 +66,7 @@ extern const char *key_names[NB_KEYS];
 /* Current keyboard configuration */
 extern u32 keyboard_cfg[NB_KEYS];
 /* Current joypad configuration */
-extern u16 joypad_cfg[NB_KEYS];
+extern u32 joypad_cfg[NB_KEYS];
 /* Number of detected joypads */
 extern u16 nbr_joy;
 


### PR DESCRIPTION
fixes #563

unlike #566, this also fixes the gtk2 frontend automatically.