### PR TITLE
Fix out-of-bounds index access

### DIFF
--- a/desmume/src/Database.cpp
+++ b/desmume/src/Database.cpp
@@ -374,7 +374,7 @@ namespace Database
 		size_t regions_num = ARRAY_SIZE(regions);
 		
 		const char* found = strchr(regions_index,code);
-		if(found) return regions[found-regions_index];
+		if(found && found-regions_index < strlen(regions_index)) return regions[found-regions_index];
 		else return unknownAsString ? "???" : NULL;
 	}
 


### PR DESCRIPTION
In the `RegionXXXForCode` function, if the value of `code` is 0, then `strchr` will return a pointer to the end of the `regions_index` string and thus the index calculation (`found-regions_index`) will result in returning an out-of-bounds value. This PR adds a check to prevent this behavior. ASan output is below for reference.

```
=================================================================
==5084==ERROR: AddressSanitizer: global-buffer-overflow on address 0x56366011b340 at pc 0x56365ff093bd bp 0x7ffc411d1ff0 sp 0x7ffc411d1fe8
READ of size 8 at 0x56366011b340 thread T0
    #0 0x56365ff093bc in Database::RegionXXXForCode(char, bool) /home/hjung/desmume/desmume/src/frontend/posix/../../Database.cpp:377:20
    #1 0x56365f7b5e6a in GameInfo::populate() /home/hjung/desmume/desmume/src/frontend/posix/../../NDSSystem.cpp:399:21
    #2 0x56365f7b5e6a in NDS_LoadROM(char const*, char const*, char const*) /home/hjung/desmume/desmume/src/frontend/posix/../../NDSSystem.cpp:711:11
    #3 0x56365f400f06 in main /home/hjung/desmume/desmume/src/frontend/posix/cli/main.cpp:486:11
    #4 0x7f593ab5478f  (/usr/lib/libc.so.6+0x2378f) (BuildId: 4a4bec3d95a1804443e852958fe59ed461135ce9)
    #5 0x7f593ab54849 in __libc_start_main (/usr/lib/libc.so.6+0x23849) (BuildId: 4a4bec3d95a1804443e852958fe59ed461135ce9)
    #6 0x56365f300ee4 in _start (/home/hjung/desmume-cli+0xf1ee4) (BuildId: 6d1d585f2ddfe118fbd4deb21a157eda10909ce8)

0x56366011b340 is located 32 bytes to the left of global variable 'makerCodes' defined in '/home/hjung/desmume/desmume/src/frontend/posix/../../Database.cpp:54' (0x56366011b360) of size 4944
0x56366011b340 is located 0 bytes to the right of global variable 'regions' defined in '/home/hjung/desmume/desmume/src/frontend/posix/../../Database.cpp:35' (0x56366011b2c0) of size 128
SUMMARY: AddressSanitizer: global-buffer-overflow /home/hjung/desmume/desmume/src/frontend/posix/../../Database.cpp:377:20 in Database::RegionXXXForCode(char, bool)
Shadow bytes around the buggy address:
  0x0ac74c01b610: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0ac74c01b620: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0ac74c01b630: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0ac74c01b640: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0ac74c01b650: f9 f9 f9 f9 f9 f9 f9 f9 00 00 00 00 00 00 00 00
=>0x0ac74c01b660: 00 00 00 00 00 00 00 00[f9]f9 f9 f9 00 00 00 00
  0x0ac74c01b670: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac74c01b680: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac74c01b690: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac74c01b6a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ac74c01b6b0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==5084==ABORTING
```