### PR TITLE
CI: limit autoconf build to 8 processes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           cd desmume/src/frontend/posix/
           autoreconf -i
           ./configure --prefix=/usr --enable-gdb-stub --enable-wifi
-          make -j
+          make -j8
           make DESTDIR=/tmp/DeSmuME install
 
       - name: Pack artifact


### PR DESCRIPTION
hopefully will prevent the OOM killer from kicking in.