### PR TITLE
Windows CI: Update deprecated github actions

### DIFF
--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: windows-2019
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup MSBuild.exe
         uses: microsoft/setup-msbuild@v1.1
@@ -24,7 +24,7 @@ jobs:
           cmd /c desmume\src\frontend\windows\ci_postbuild.bat
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: desmume-win-x64
           path: desmume/src/frontend/windows/__bins/*.exe


### PR DESCRIPTION
Fixes this warning about deprecated NodeJS versions in the GitHub-supplied actions `checkout` and `upload-artifact`:

![image](https://github.com/TASEmulators/desmume/assets/18552155/eaa3eb96-b4df-4958-b9a1-e7ae20a1bf01)

Sample run [here](https://github.com/SimonAfek/desmume/actions/runs/4936859243).

