### PR TITLE
Slot2: Sega Card Reader fixes

### DIFF
--- a/desmume/src/addons/slot2_hcv1000.cpp
+++ b/desmume/src/addons/slot2_hcv1000.cpp
@@ -79,3 +79,9 @@ void HCV1000_setReady()
 {
 	hcv1000_cnt &= ~0x80;
 }
+
+void HCV1000_setBarcode(std::string barcode)
+{
+	barcode.resize(16, '_');
+	memcpy(hcv1000_data, barcode.c_str(), barcode.length());
+}

--- a/desmume/src/frontend/windows/gbaslot_config.cpp
+++ b/desmume/src/frontend/windows/gbaslot_config.cpp
@@ -36,7 +36,7 @@ u8			last_type = 0;
 char		tmp_cflash_filename[MAX_PATH] = { 0 };
 char		tmp_cflash_path[MAX_PATH] = { 0 };
 char		tmp_gbagame_filename[MAX_PATH] = { 0 };
-TCHAR		tmp_hcv1000_barcode[17] = { 0 };
+char		tmp_hcv1000_barcode[17] = { 0 };
 ADDON_CFLASH_MODE	tmp_CFlashMode = ADDON_CFLASH_MODE_RomPath;
 HWND		OKbutton = NULL;
 bool		_OKbutton = false;
@@ -50,7 +50,8 @@ SHCV1000	tmp_HCV1000;
 std::string win32_CFlash_cfgDirectory, win32_CFlash_cfgFileName;
 UINT win32_CFlash_cfgMode;
 std::string win32_GBA_cfgRomPath;
-std::string win32_HCV1000_barcode;
+
+std::string slot2_HCV1000_barcode;
 
 INT_PTR CALLBACK GbaSlotNone(HWND dialog, UINT msg,WPARAM wparam,LPARAM lparam)
 {
@@ -305,7 +306,7 @@ INT_PTR CALLBACK GbaSlotHCV1000(HWND dialog, UINT msg, WPARAM wparam, LPARAM lpa
 				switch (LOWORD(wparam))
 				{
 					case IDC_HCVBARCODE:
-						GetWindowText(GetDlgItem(dialog, IDC_HCVBARCODE), tmp_hcv1000_barcode, 16);
+						GetWindowText(GetDlgItem(dialog, IDC_HCVBARCODE), tmp_hcv1000_barcode, 17);
 					
 						return FALSE;
 				}
@@ -619,7 +620,7 @@ void GBAslotDialog(HWND hwnd)
 	strcpy(tmp_cflash_filename, win32_CFlash_cfgFileName.c_str());
 	strcpy(tmp_cflash_path, win32_CFlash_cfgDirectory.c_str());
 	strcpy(tmp_gbagame_filename, win32_GBA_cfgRomPath.c_str());
-	strcpy(tmp_hcv1000_barcode, win32_HCV1000_barcode.c_str());
+	strcpy(tmp_hcv1000_barcode, slot2_HCV1000_barcode.c_str());
 	memcpy(&tmp_Guitar, &Guitar, sizeof(Guitar));
 	memcpy(&tmp_Piano, &Piano, sizeof(Piano));
 	memcpy(&tmp_Paddle, &Paddle, sizeof(Paddle));
@@ -689,10 +690,9 @@ void GBAslotDialog(HWND hwnd)
 			case NDS_SLOT2_PASSME:
 				break;
 			case NDS_SLOT2_HCV1000:
-				win32_HCV1000_barcode = tmp_hcv1000_barcode;
+				slot2_HCV1000_barcode = tmp_hcv1000_barcode;
 				memcpy(&HCV1000, &tmp_HCV1000, sizeof(tmp_HCV1000));
-				memset(hcv1000_data, 0x5F, 16);
-				memcpy(hcv1000_data, win32_HCV1000_barcode.c_str(), (win32_HCV1000_barcode.length() <= 16) ? win32_HCV1000_barcode.length() : 16);
+				HCV1000_setBarcode(slot2_HCV1000_barcode);
 				WritePrivateProfileString("Slot2.HCV1000", "barcode", tmp_hcv1000_barcode, IniName);
 				WritePrivateProfileInt("Slot2.HCV1000", "scankey", HCV1000.SCANKEY, IniName);
 				break;

--- a/desmume/src/frontend/windows/gbaslot_config.h
+++ b/desmume/src/frontend/windows/gbaslot_config.h
@@ -24,7 +24,8 @@
 extern std::string win32_CFlash_cfgDirectory, win32_CFlash_cfgFileName;
 extern UINT win32_CFlash_cfgMode;
 extern std::string win32_GBA_cfgRomPath;
-extern std::string win32_HCV1000_barcode;
+
+extern std::string slot2_HCV1000_barcode;
 
 extern void GBAslotDialog(HWND hwnd);
 

--- a/desmume/src/frontend/windows/main.cpp
+++ b/desmume/src/frontend/windows/main.cpp
@@ -2198,8 +2198,9 @@ int _main()
 	win32_CFlash_cfgDirectory = GetPrivateProfileStdString("Slot2.CFlash", "path", "");
 	win32_CFlash_cfgFileName = GetPrivateProfileStdString("Slot2.CFlash", "filename", "");
 	win32_GBA_cfgRomPath = GetPrivateProfileStdString("Slot2.GBAgame", "filename", "");
-	win32_HCV1000_barcode = GetPrivateProfileStdString("Slot2.HCV1000", "barcode", "");
-	memcpy(hcv1000_data, win32_HCV1000_barcode.c_str(), (win32_HCV1000_barcode.length() <= 16) ? win32_HCV1000_barcode.length() : 16);
+
+	slot2_HCV1000_barcode = GetPrivateProfileStdString("Slot2.HCV1000", "barcode", "").substr(0, 16);
+	HCV1000_setBarcode(slot2_HCV1000_barcode);
 
 	cmdline.process_addonCommands();
 	WIN_InstallCFlash();

--- a/desmume/src/slot2.h
+++ b/desmume/src/slot2.h
@@ -143,7 +143,6 @@ bool slot2_read(u32 addr, T &val);
 extern std::string GBACartridge_RomPath;
 extern std::string GBACartridge_SRAMPath;
 extern void (*FeedbackON)(bool enable);				// feedback on/off
-extern char hcv1000_data[16];
 
 enum ADDON_CFLASH_MODE
 {
@@ -160,4 +159,5 @@ void Paddle_SetValue(u16 theValue);
 extern void guitarGrip_setKey(bool green, bool red, bool yellow, bool blue); // Guitar grip keys
 extern void piano_setKey(bool c, bool cs, bool d, bool ds, bool e, bool f, bool fs, bool g, bool gs, bool a, bool as, bool b, bool hic); //piano keys
 extern void HCV1000_setReady();
+extern void HCV1000_setBarcode(std::string barcode);
 #endif //__SLOT_H__


### PR DESCRIPTION
- Off-by-one in GetWindowText call that was limiting barcode data to 15 characters
- Limit string read from ini to 16 characters
- Add function to the addon to set the barcode data from an std::string to make things cleaner