### PR TITLE
GTK: make OSD scalable

### DIFF
--- a/desmume/src/frontend/modules/osd/agg/agg2d.inl
+++ b/desmume/src/frontend/modules/osd/agg/agg2d.inl
@@ -1370,6 +1370,17 @@ AGG2D_TEMPLATE void TAGG2D::text(double x, double y, const wchar_t* str, unsigne
     }
 
 }
+
+AGG2D_TEMPLATE double TAGG2D::textWidth(const char* str)
+{
+	return textWidth(str, (unsigned int)strlen(str));
+}
+
+AGG2D_TEMPLATE void TAGG2D::text(double x, double y, const char* str, bool roundOff, double dx, double dy)
+{
+	text(x, y, str, (unsigned int)strlen(str), roundOff, dx, dy);
+}
+
 #endif
 
 //------------------------------------------------------------------------
@@ -1945,11 +1956,11 @@ AGG2D_TEMPLATE void TAGG2D::render(FontRasterizer& ras, FontScanline& sl)
 {
     if(m_blendMode == BlendAlpha)
     {
-        Agg2DRenderer::render(*this, m_renBase, m_renSolid, ras, sl);
+        Agg2DRenderer<PixFormatSet, PixFormatSet>::render(*this, m_renBase, m_renSolid, ras, sl);
     }
     else
     {
-        Agg2DRenderer::render(*this, m_renBaseComp, m_renSolidComp, ras, sl);
+        Agg2DRenderer<PixFormatSet, PixFormatSet>::render(*this, m_renBaseComp, m_renSolidComp, ras, sl);
     }
 }
 

--- a/desmume/src/frontend/modules/osd/agg/agg_osd.cpp
+++ b/desmume/src/frontend/modules/osd/agg/agg_osd.cpp
@@ -561,24 +561,24 @@ static void DrawStateSlots(){
 
 	if(alpha!=0)
 	{
-		aggDraw.hud->lineWidth(1.0);
+		aggDraw.hud->lineWidth(osd->scale);
 		aggDraw.hud->lineColor(0, 0, 0, alpha);
 		aggDraw.hud->fillColor(255, 255, 255, alpha);
 
-		for ( int i = 0, xpos=0; i < 10; xpos=xpos+24) {
+		for ( int i = 0, xpos=0; i < 10; xpos=xpos+24*osd->scale) {
 
 			int yheight=0;
 
-			aggDraw.hud->fillLinearGradient(xloc + xpos, yloc - yheight, xloc + 22 + xpos, yloc + 20 + yheight+20, agg::rgba8(100,200,255,alpha), agg::rgba8(255,255,255,0));
+			aggDraw.hud->fillLinearGradient(xloc + xpos, yloc - yheight, xloc + 22*osd->scale + xpos, yloc + 20*osd->scale + yheight+20*osd->scale, agg::rgba8(100,200,255,alpha), agg::rgba8(255,255,255,0));
 
 			if(lastSaveState == i) {
-				yheight = 5;
-				aggDraw.hud->fillLinearGradient(xloc + xpos, yloc - yheight, 22 + xloc + xpos, yloc + 20 + yheight+20, agg::rgba8(100,255,255,alpha), agg::rgba8(255,255,255,0));
+				yheight = 5*osd->scale;
+				aggDraw.hud->fillLinearGradient(xloc + xpos, yloc - yheight, 22*osd->scale + xloc + xpos, yloc + 20*osd->scale + yheight+20*osd->scale, agg::rgba8(100,255,255,alpha), agg::rgba8(255,255,255,0));
 			}
 
-			aggDraw.hud->rectangle(xloc + xpos , yloc - yheight, xloc + 22 + xpos , yloc + 20 + yheight);
+			aggDraw.hud->rectangle(xloc + xpos , yloc - yheight, xloc + 22*osd->scale + xpos , yloc + 20*osd->scale + yheight);
 			snprintf(number, 10, "%d", i);
-			RenderTextAutoVector(xloc + 1 + xpos + 4, yloc+4, std::string(number), true, osd ? osd->scale : 1);
+			RenderTextAutoVector(xloc + osd->scale + xpos + 4*osd->scale, yloc+4*osd->scale, std::string(number), true, osd->scale);
 			i++;
 		}
 	}

--- a/desmume/src/frontend/modules/osd/agg/agg_osd.cpp
+++ b/desmume/src/frontend/modules/osd/agg/agg_osd.cpp
@@ -89,7 +89,7 @@ static T calcY(T y) // alters a GUI element y coordinate as necessary to obey sw
 	return y;
 }
 
-static void RenderTextAutoVector(double x, double y, const std::string& str, bool shadow = true, int shadowOffset = 1)
+static void RenderTextAutoVector(double x, double y, const std::string& str, bool shadow = true, double shadowOffset = 1.0)
 {
 #ifdef AGG2D_USE_VECTORFONTS
 	bool render_vect = false;
@@ -174,7 +174,7 @@ void HudClickRelease(HudStruct *hudstruct) {
 
 void HudStruct::reset()
 {
-	int sc=(osd ? osd->scale : 1);
+	double sc=(osd ? osd->scale : 1.0);
 	
 	FpsDisplay.x=0;
 	FpsDisplay.y=5*sc;
@@ -505,8 +505,8 @@ static void OSD_HandleTouchDisplay() {
 	// note: calcY should not be used in this function.
 	aggDraw.hud->lineWidth(osd->scale);
 
-	temptouch.X = NDS_getRawUserInput().touch.touchX >> 4 * osd->scale;
-	temptouch.Y = NDS_getRawUserInput().touch.touchY >> 4 * osd->scale;
+	temptouch.X = (NDS_getRawUserInput().touch.touchX >> 4) * osd->scale;
+	temptouch.Y = (NDS_getRawUserInput().touch.touchY >> 4) * osd->scale;
 
 	if(touchshadow) {
 
@@ -709,7 +709,7 @@ OSDCLASS::OSDCLASS(u8 core)
 
 	singleScreen = false;
 	swapScreens = false;
-	scale=1;
+	scale = 1.0;
 	needUpdate = false;
 #ifdef AGG2D_USE_VECTORFONTS
 	useVectorFonts = false;
@@ -794,7 +794,7 @@ void OSDCLASS::update()
 			for (int i=0; i < lastLineText; i++)
 			{
 				aggDraw.hud->lineColor(lineColor[i]);
-				RenderTextAutoVector(lineText_x, lineText_y+(i*16), lineText[i], true, osd ? osd->scale : 1);
+				RenderTextAutoVector(lineText_x, lineText_y+(i*16), lineText[i], true, osd->scale);
 			}
 		}
 		else
@@ -876,7 +876,7 @@ void OSDCLASS::addFixed(u16 x, u16 y, const char *fmt, ...)
 	va_end(list);
 
 	aggDraw.hud->lineColor(255,255,255);
-	RenderTextAutoVector(x, calcY(y), msg, true, osd ? osd->scale : 1);
+	RenderTextAutoVector(x, calcY(y), msg, true, osd->scale);
 
 	needUpdate = true;
 }

--- a/desmume/src/frontend/modules/osd/agg/agg_osd.cpp
+++ b/desmume/src/frontend/modules/osd/agg/agg_osd.cpp
@@ -50,13 +50,23 @@ static s64 hudTimer;
 
 static void SetHudDummy (HudCoordinates *hud)
 {
-	hud->x=666;
-	hud->y=666;
+	hud->x=-666;
+	hud->y=-666;
 }
 
 static bool IsHudDummy (HudCoordinates *hud)
 {
-	return (hud->x == 666 && hud->y == 666);
+	return (hud->x == -666 && hud->y == -666);
+}
+
+static int ScreenWidth()
+{
+	return 256*osd->scale;
+}
+
+static int ScreenHeight()
+{
+	return 192*osd->scale;
 }
 
 template<typename T>
@@ -64,19 +74,45 @@ static T calcY(T y) // alters a GUI element y coordinate as necessary to obey sw
 {
 	if(osd->singleScreen)
 	{
-		if(y >= 192)
-			y -= 192;
+		if(y >= ScreenHeight())
+			y -= ScreenHeight();
 		if(osd->swapScreens)
-			y += 192;
+			y += ScreenHeight();
 	}
 	else if(osd->swapScreens)
 	{
-		if(y >= 192)
-			y -= 192;
+		if(y >= ScreenHeight())
+			y -= ScreenHeight();
 		else
-			y += 192;
+			y += ScreenHeight();
 	}
 	return y;
+}
+
+static void RenderTextAutoVector(double x, double y, const std::string& str, bool shadow = true, int shadowOffset = 1)
+{
+#ifdef AGG2D_USE_VECTORFONTS
+	bool render_vect = false;
+	if(osd)
+		if(osd->useVectorFonts)
+			render_vect = true;
+	if(render_vect)
+	{
+		if(shadow)
+			aggDraw.hud->renderVectorFontTextDropshadowed(x, y, str, shadowOffset);
+		else
+			aggDraw.hud->renderVectorFontText(x, y, str);
+	}
+	else
+	{
+#endif
+	if(shadow)
+		aggDraw.hud->renderTextDropshadowed(x, y, str);
+	else
+		aggDraw.hud->renderText(x, y, str);
+#ifdef AGG2D_USE_VECTORFONTS
+	}
+#endif
 }
 
 void EditHud(s32 x, s32 y, HudStruct *hudstruct) {
@@ -108,8 +144,10 @@ void EditHud(s32 x, s32 y, HudStruct *hudstruct) {
 		//sanity checks
 		if(hud.x < 0)  hud.x = 0;
 		if(hud.y < 0)  hud.y = 0;
-		if(hud.x > 245)hud.x = 245; //margins
-		if(hud.y > 384-16)hud.y = 384-16;
+		if(hud.x > ScreenWidth()-11*osd->scale)
+			hud.x = ScreenWidth()-11*osd->scale; //margins
+		if(hud.y > ScreenHeight()*2-16*osd->scale)
+			hud.y = ScreenHeight()*2-16*osd->scale;
 
 		if(hud.clicked)
 		{
@@ -136,45 +174,47 @@ void HudClickRelease(HudStruct *hudstruct) {
 
 void HudStruct::reset()
 {
+	int sc=(osd ? osd->scale : 1);
+	
 	FpsDisplay.x=0;
-	FpsDisplay.y=5;
-	FpsDisplay.xsize=166;
-	FpsDisplay.ysize=10;
+	FpsDisplay.y=5*sc;
+	FpsDisplay.xsize=166*sc;
+	FpsDisplay.ysize=10*sc;
 
 	FrameCounter.x=0;
-	FrameCounter.y=25;
-	FrameCounter.xsize=60;
-	FrameCounter.ysize=10;
+	FrameCounter.y=25*sc;
+	FrameCounter.xsize=60*sc;
+	FrameCounter.ysize=10*sc;
 
 	InputDisplay.x=0;
-	InputDisplay.y=45;
-	InputDisplay.xsize=220;
-	InputDisplay.ysize=10;
+	InputDisplay.y=45*sc;
+	InputDisplay.xsize=220*sc;
+	InputDisplay.ysize=10*sc;
 
-	GraphicalInputDisplay.x=8;
-	GraphicalInputDisplay.y=328;
-	GraphicalInputDisplay.xsize=102;
-	GraphicalInputDisplay.ysize=50;
+	GraphicalInputDisplay.x=8*sc;
+	GraphicalInputDisplay.y=328*sc;
+	GraphicalInputDisplay.xsize=102*sc;
+	GraphicalInputDisplay.ysize=50*sc;
 
 	LagFrameCounter.x=0;
-	LagFrameCounter.y=65;
-	LagFrameCounter.xsize=30;
-	LagFrameCounter.ysize=10;
+	LagFrameCounter.y=65*sc;
+	LagFrameCounter.xsize=30*sc;
+	LagFrameCounter.ysize=10*sc;
 	
 	Microphone.x=0;
-	Microphone.y=85;
-	Microphone.xsize=20;
-	Microphone.ysize=10;
+	Microphone.y=85*sc;
+	Microphone.xsize=20*sc;
+	Microphone.ysize=10*sc;
 
 	RTCDisplay.x=0;
-	RTCDisplay.y=105;
-	RTCDisplay.xsize=220;
-	RTCDisplay.ysize=10;
+	RTCDisplay.y=105*sc;
+	RTCDisplay.xsize=220*sc;
+	RTCDisplay.ysize=10*sc;
 
-	SavestateSlots.x = 8;
-	SavestateSlots.y = 160;
-	SavestateSlots.xsize = 240;
-	SavestateSlots.ysize = 24;
+	SavestateSlots.x = 8*sc;
+	SavestateSlots.y = 160*sc;
+	SavestateSlots.xsize = 240*sc;
+	SavestateSlots.ysize = 24*sc;
 
 	#ifdef _MSC_VER
 	#define AGG_OSD_SETTING(which,comp) which.comp = GetPrivateProfileInt("HudEdit", #which "." #comp, which.comp, IniName);
@@ -184,6 +224,51 @@ void HudStruct::reset()
 
 	SetHudDummy(&Dummy);
 	clicked = false;
+}
+
+void HudStruct::rescale(double oldScale, double newScale)
+{
+	double sc=newScale/oldScale;
+	
+	FpsDisplay.x*=sc;
+	FpsDisplay.y*=sc;
+	FpsDisplay.xsize*=sc;
+	FpsDisplay.ysize*=sc;
+
+	FrameCounter.x*=sc;
+	FrameCounter.y*=sc;
+	FrameCounter.xsize*=sc;
+	FrameCounter.ysize*=sc;
+
+	InputDisplay.x*=sc;
+	InputDisplay.y*=sc;
+	InputDisplay.xsize*=sc;
+	InputDisplay.ysize*=sc;
+
+	GraphicalInputDisplay.x*=sc;
+	GraphicalInputDisplay.y*=sc;
+	GraphicalInputDisplay.xsize*=sc;
+	GraphicalInputDisplay.ysize*=sc;
+
+	LagFrameCounter.x*=sc;
+	LagFrameCounter.y*=sc;
+	LagFrameCounter.xsize*=sc;
+	LagFrameCounter.ysize*=sc;
+	
+	Microphone.x*=sc;
+	Microphone.y*=sc;
+	Microphone.xsize*=sc;
+	Microphone.ysize*=sc;
+
+	RTCDisplay.x*=sc;
+	RTCDisplay.y*=sc;
+	RTCDisplay.xsize*=sc;
+	RTCDisplay.ysize*=sc;
+
+	SavestateSlots.x*=sc;
+	SavestateSlots.y*=sc;
+	SavestateSlots.xsize*=sc;
+	SavestateSlots.ysize*=sc;
 }
 
 static void joyFill(int n) {
@@ -235,8 +320,8 @@ static void drawPad(double x, double y, double ratio) {
 	// aligning to odd half-pixel boundaries prevents agg2d from blurring thin straight lines
 	x = floor(x) + 0.5;
 	y = floor(calcY(y)) + 0.5;
-	double xc = 41 - 0.5;
-	double yc = 20 - 0.5;
+	double xc = 41*osd->scale - 0.5;
+	double yc = 20*osd->scale - 0.5;
 
 	aggDraw.hud->lineColor(128,128,128,255);
 
@@ -252,12 +337,12 @@ static void drawPad(double x, double y, double ratio) {
 	aggDraw.hud->roundedRect (screenLeft, screenTop, screenRight, screenBottom, 1);
 
 
-	joyEllipse(.89,.45,xc,yc,x,y,ratio,1,6);//B
-	joyEllipse(.89,.22,xc,yc,x,y,ratio,1,3);//X
-	joyEllipse(.83,.34,xc,yc,x,y,ratio,1,4);//Y
-	joyEllipse(.95,.34,xc,yc,x,y,ratio,1,5);//A
-	joyEllipse(.82,.716,xc,yc,x,y,ratio,.5,7);//Start
-	joyEllipse(.82,.842,xc,yc,x,y,ratio,.5,8);//Select
+	joyEllipse(.89,.45,xc,yc,x,y,ratio,osd->scale,6);//B
+	joyEllipse(.89,.22,xc,yc,x,y,ratio,osd->scale,3);//X
+	joyEllipse(.83,.34,xc,yc,x,y,ratio,osd->scale,4);//Y
+	joyEllipse(.95,.34,xc,yc,x,y,ratio,osd->scale,5);//A
+	joyEllipse(.82,.716,xc,yc,x,y,ratio,osd->scale * .5,7);//Start
+	joyEllipse(.82,.842,xc,yc,x,y,ratio,osd->scale * .5,8);//Select
 
 
 	double dpadPoints [][2] = {
@@ -311,29 +396,29 @@ static void drawPad(double x, double y, double ratio) {
 	// touch pad
 	{
 		BOOL gameTouchOn = nds.isTouch;
-		double gameTouchX = screenLeft+1 + (nds.scr_touchX * 0.0625) * (screenRight - screenLeft - 2) / 256.0;
-		double gameTouchY = screenTop+1 + (nds.scr_touchY * 0.0625) * (screenBottom - screenTop - 2) / 192.0;
+		double gameTouchX = screenLeft+1 + (nds.scr_touchX * osd->scale * 0.0625) * (screenRight - screenLeft - 2) / (double)ScreenWidth();
+		double gameTouchY = screenTop+1 + (nds.scr_touchY * osd->scale * 0.0625) * (screenBottom - screenTop - 2) / (double)ScreenHeight();
 		bool physicalTouchOn = NDS_getRawUserInput().touch.isTouch;
-		double physicalTouchX = screenLeft+1 + (NDS_getRawUserInput().touch.touchX * 0.0625) * (screenRight - screenLeft - 2) / 256.0;
-		double physicalTouchY = screenTop+1 + (NDS_getRawUserInput().touch.touchY * 0.0625) * (screenBottom - screenTop - 2) / 192.0;
+		double physicalTouchX = screenLeft+1 + (NDS_getRawUserInput().touch.touchX * osd->scale * 0.0625) * (screenRight - screenLeft - 2) / (double)ScreenWidth();
+		double physicalTouchY = screenTop+1 + (NDS_getRawUserInput().touch.touchY * osd->scale * 0.0625) * (screenBottom - screenTop - 2) / (double)ScreenHeight();
 		if(gameTouchOn && physicalTouchOn && gameTouchX == physicalTouchX && gameTouchY == physicalTouchY)
 		{
 			aggDraw.hud->fillColor(0,0,0,255);
-			aggDraw.hud->ellipse(gameTouchX, gameTouchY, ratio*0.37, ratio*0.37);
+			aggDraw.hud->ellipse(gameTouchX, gameTouchY, osd->scale*ratio*0.37, osd->scale*ratio*0.37);
 		}
 		else
 		{
 			if(physicalTouchOn)
 			{
 				aggDraw.hud->fillColor(0,0,0,128);
-				aggDraw.hud->ellipse(physicalTouchX, physicalTouchY, ratio*0.5, ratio*0.5);
+				aggDraw.hud->ellipse(physicalTouchX, physicalTouchY, osd->scale*ratio*0.5, osd->scale*ratio*0.5);
 				aggDraw.hud->fillColor(0,255,0,255);
-				aggDraw.hud->ellipse(physicalTouchX, physicalTouchY, ratio*0.37, ratio*0.37);
+				aggDraw.hud->ellipse(physicalTouchX, physicalTouchY, osd->scale*ratio*0.37, osd->scale*ratio*0.37);
 			}
 			if(gameTouchOn)
 			{
 				aggDraw.hud->fillColor(255,0,0,255);
-				aggDraw.hud->ellipse(gameTouchX, gameTouchY, ratio*0.37, ratio*0.37);
+				aggDraw.hud->ellipse(gameTouchX, gameTouchY, osd->scale*ratio*0.37, osd->scale*ratio*0.37);
 			}
 		}
 	}
@@ -379,8 +464,8 @@ static void TextualInputDisplay() {
 		// cast from char to std::string is a bit awkward
 		std::string str(buttonChars+i, 2);
 		str[1] = '\0';
-
-		aggDraw.hud->renderTextDropshadowed(x, calcY(Hud.InputDisplay.y), str);
+		
+		RenderTextAutoVector(x, calcY(Hud.InputDisplay.y), str, true, osd ? osd->scale : 1);
 	}
 
 	// touch pad
@@ -396,7 +481,7 @@ static void TextualInputDisplay() {
 		{
 			sprintf(str, "%d,%d", gameTouchX, gameTouchY);
 			aggDraw.hud->lineColor(255,255,255,255);
-			aggDraw.hud->renderTextDropshadowed(x, calcY(Hud.InputDisplay.y), str);
+			RenderTextAutoVector(x, calcY(Hud.InputDisplay.y), str, true, osd ? osd->scale : 1);
 		}
 		else
 		{
@@ -404,13 +489,13 @@ static void TextualInputDisplay() {
 			{
 				sprintf(str, "%d,%d", gameTouchX, gameTouchY);
 				aggDraw.hud->lineColor(255,48,48,255);
-				aggDraw.hud->renderTextDropshadowed(x, calcY(Hud.InputDisplay.y)-(physicalTouchOn?8:0), str);
+				RenderTextAutoVector(x, calcY(Hud.InputDisplay.y)-(physicalTouchOn?8:0), str, true, osd ? osd->scale : 1);
 			}
 			if(physicalTouchOn)
 			{
 				sprintf(str, "%d,%d", physicalTouchX, physicalTouchY);
 				aggDraw.hud->lineColor(0,192,0,255);
-				aggDraw.hud->renderTextDropshadowed(x, calcY(Hud.InputDisplay.y)+(gameTouchOn?8:0), str);
+				RenderTextAutoVector(x, calcY(Hud.InputDisplay.y)+(gameTouchOn?8:0), str, true, osd ? osd->scale : 1);
 			}
 		}
 	}
@@ -418,10 +503,10 @@ static void TextualInputDisplay() {
 
 static void OSD_HandleTouchDisplay() {
 	// note: calcY should not be used in this function.
-	aggDraw.hud->lineWidth(1.0);
+	aggDraw.hud->lineWidth(osd->scale);
 
-	temptouch.X = NDS_getRawUserInput().touch.touchX >> 4;
-	temptouch.Y = NDS_getRawUserInput().touch.touchY >> 4;
+	temptouch.X = NDS_getRawUserInput().touch.touchX >> 4 * osd->scale;
+	temptouch.Y = NDS_getRawUserInput().touch.touchY >> 4 * osd->scale;
 
 	if(touchshadow) {
 
@@ -432,27 +517,27 @@ static void OSD_HandleTouchDisplay() {
 			temptouch = touch[i];
 			if(temptouch.X != 0 || temptouch.Y != 0) {
 				aggDraw.hud->lineColor(0, 255, 0, touchalpha[i]);
-				aggDraw.hud->line(temptouch.X - 256, temptouch.Y + 192, temptouch.X + 256, temptouch.Y + 192); //horiz
-				aggDraw.hud->line(temptouch.X, temptouch.Y - 256, temptouch.X, temptouch.Y + 384); //vert
+				aggDraw.hud->line(temptouch.X - ScreenWidth(), temptouch.Y + ScreenHeight(), temptouch.X + ScreenWidth(), temptouch.Y + ScreenHeight()); //horiz
+				aggDraw.hud->line(temptouch.X, temptouch.Y - ScreenWidth(), temptouch.X, temptouch.Y + ScreenHeight()*2); //vert
 				aggDraw.hud->fillColor(0, 0, 0, touchalpha[i]);
-				aggDraw.hud->rectangle(temptouch.X-1, temptouch.Y + 192-1, temptouch.X+1, temptouch.Y + 192+1);
+				aggDraw.hud->rectangle(temptouch.X-1, temptouch.Y + ScreenHeight()-1, temptouch.X+1, temptouch.Y + ScreenHeight()+1);
 			}
 		}
 	}
 	else
 		if(NDS_getRawUserInput().touch.isTouch) {
 			aggDraw.hud->lineColor(0, 255, 0, 128);
-			aggDraw.hud->line(temptouch.X - 256, temptouch.Y + 192, temptouch.X + 256, temptouch.Y + 192); //horiz
-			aggDraw.hud->line(temptouch.X, temptouch.Y - 256, temptouch.X, temptouch.Y + 384); //vert
+			aggDraw.hud->line(temptouch.X - ScreenWidth(), temptouch.Y + ScreenHeight(), temptouch.X + ScreenWidth(), temptouch.Y + ScreenHeight()); //horiz
+			aggDraw.hud->line(temptouch.X, temptouch.Y - ScreenWidth(), temptouch.X, temptouch.Y + ScreenHeight()*2); //vert
 		}
 
 	if(nds.isTouch)
 	{
-		temptouch.X = nds.scr_touchX / 16;
-		temptouch.Y = nds.scr_touchY / 16;
+		temptouch.X = nds.scr_touchX / 16 * osd->scale;
+		temptouch.Y = nds.scr_touchY / 16 * osd->scale;
 		aggDraw.hud->lineColor(255, 0, 0, 128);
-		aggDraw.hud->line(temptouch.X - 256, temptouch.Y + 192, temptouch.X + 256, temptouch.Y + 192); //horiz
-		aggDraw.hud->line(temptouch.X, temptouch.Y - 256, temptouch.X, temptouch.Y + 384); //vert
+		aggDraw.hud->line(temptouch.X - ScreenWidth(), temptouch.Y + ScreenHeight(), temptouch.X + ScreenWidth(), temptouch.Y + ScreenHeight()); //horiz
+		aggDraw.hud->line(temptouch.X, temptouch.Y - ScreenWidth(), temptouch.X, temptouch.Y + ScreenHeight()*2); //vert
 	}
 
 }
@@ -493,7 +578,7 @@ static void DrawStateSlots(){
 
 			aggDraw.hud->rectangle(xloc + xpos , yloc - yheight, xloc + 22 + xpos , yloc + 20 + yheight);
 			snprintf(number, 10, "%d", i);
-			aggDraw.hud->renderText(xloc + 1 + xpos + 4, yloc+4, std::string(number));
+			RenderTextAutoVector(xloc + 1 + xpos + 4, yloc+4, std::string(number), true, osd ? osd->scale : 1);
 			i++;
 		}
 	}
@@ -511,10 +596,10 @@ static void DrawEditableElementIndicators()
 		HudCoordinates &hud = Hud.hud(i);
 		aggDraw.hud->fillColor(0,0,0,0);
 		aggDraw.hud->lineColor(0,0,0,64);
-		aggDraw.hud->lineWidth(2.0);
+		aggDraw.hud->lineWidth(2.0*osd->scale);
 		aggDraw.hud->rectangle(hud.x,calcY(hud.y),hud.x+hud.xsize+1.0,calcY(hud.y)+hud.ysize+1.0);
 		aggDraw.hud->lineColor(255,hud.clicked?127:255,0,255);
-		aggDraw.hud->lineWidth(1.0);
+		aggDraw.hud->lineWidth(osd->scale);
 		aggDraw.hud->rectangle(hud.x-0.5,calcY(hud.y)-0.5,hud.x+hud.xsize+0.5,calcY(hud.y)+hud.ysize+0.5);
 		i++;
 	}
@@ -624,9 +709,11 @@ OSDCLASS::OSDCLASS(u8 core)
 
 	singleScreen = false;
 	swapScreens = false;
-
+	scale=1;
 	needUpdate = false;
-
+#ifdef AGG2D_USE_VECTORFONTS
+	useVectorFonts = false;
+#endif
 	if (core==0) 
 		strcpy(name,"Core A");
 	else
@@ -707,7 +794,7 @@ void OSDCLASS::update()
 			for (int i=0; i < lastLineText; i++)
 			{
 				aggDraw.hud->lineColor(lineColor[i]);
-				aggDraw.hud->renderTextDropshadowed(lineText_x,lineText_y+(i*16),lineText[i]);
+				RenderTextAutoVector(lineText_x, lineText_y+(i*16), lineText[i], true, osd ? osd->scale : 1);
 			}
 		}
 		else
@@ -789,7 +876,7 @@ void OSDCLASS::addFixed(u16 x, u16 y, const char *fmt, ...)
 	va_end(list);
 
 	aggDraw.hud->lineColor(255,255,255);
-	aggDraw.hud->renderTextDropshadowed(x,calcY(y),msg);
+	RenderTextAutoVector(x, calcY(y), msg, true, osd ? osd->scale : 1);
 
 	needUpdate = true;
 }

--- a/desmume/src/frontend/modules/osd/agg/agg_osd.h
+++ b/desmume/src/frontend/modules/osd/agg/agg_osd.h
@@ -112,7 +112,7 @@ public:
 	char	name[7];		// for debuging
 	bool    singleScreen;
 	bool    swapScreens;
-	int		scale;
+	double	scale;
 #ifdef AGG2D_USE_VECTORFONTS
 	bool	useVectorFonts;
 #endif

--- a/desmume/src/frontend/modules/osd/agg/agg_osd.h
+++ b/desmume/src/frontend/modules/osd/agg/agg_osd.h
@@ -73,6 +73,7 @@ public:
 
 	HudCoordinates &hud(int i) { return ((HudCoordinates*)this)[i]; }
 	void reset();
+	void rescale(double oldScale, double newScale);
 
 	int fps, fps3d, cpuload[2], cpuloopIterationCount;
 	char rtcString[25];
@@ -92,7 +93,7 @@ class OSDCLASS
 private:
 	u64		offset;
 	u8		mode;
-
+	
 	u16		rotAngle;
 
 	u16		lineText_x;
@@ -111,6 +112,10 @@ public:
 	char	name[7];		// for debuging
 	bool    singleScreen;
 	bool    swapScreens;
+	int		scale;
+#ifdef AGG2D_USE_VECTORFONTS
+	bool	useVectorFonts;
+#endif
 
 	OSDCLASS(u8 core);
 	~OSDCLASS();
@@ -125,7 +130,7 @@ public:
 	void	addLine(const char* fmt, va_list args);
 	void	addFixed(u16 x, u16 y, const char *fmt, ...);
 	void	border(bool enabled);
-
+	
 	void SaveHudEditor();
 };
 

--- a/desmume/src/frontend/modules/osd/agg/aggdraw.cpp
+++ b/desmume/src/frontend/modules/osd/agg/aggdraw.cpp
@@ -118,11 +118,7 @@ static void Agg_init_fonts()
 
 AggDraw_Desmume aggDraw;
 
-#if defined(WIN32) || defined(HOST_LINUX)
 T_AGG_RGBA agg_targetScreen(0, GPU_FRAMEBUFFER_NATIVE_WIDTH, GPU_FRAMEBUFFER_NATIVE_HEIGHT*2, 1024);
-#else
-T_AGG_RGB555 agg_targetScreen(0, GPU_FRAMEBUFFER_NATIVE_WIDTH, GPU_FRAMEBUFFER_NATIVE_HEIGHT*2, 512);
-#endif
 
 static std::vector<u32> luaBuffer(GPU_FRAMEBUFFER_NATIVE_WIDTH*GPU_FRAMEBUFFER_NATIVE_HEIGHT*2);
 T_AGG_RGBA agg_targetLua((u8*)luaBuffer.data(), GPU_FRAMEBUFFER_NATIVE_WIDTH, GPU_FRAMEBUFFER_NATIVE_HEIGHT*2, 1024);
@@ -139,6 +135,7 @@ static AggDrawTarget* targets[] = {
 void Agg_init()
 {
 	Agg_init_fonts();
+	aggDraw.screenBytesPerPixel = 4;
 	aggDraw.screen = targets[0];
 	aggDraw.hud = targets[1];
 	aggDraw.lua = targets[2];
@@ -167,13 +164,7 @@ void Agg_setCustomSize(int w, int h)
 	hudBuffer.resize(w*h);
 	luaBuffer.resize(w*h);
 	if(aggDraw.screen)
-	{
-#if defined(WIN32) || defined(HOST_LINUX)
-		aggDraw.screen->setDrawTargetDims(0, w, h, w*4);
-#else
-		aggDraw.screen->setDrawTargetDims(0, w, h, w*2);
-#endif
-	}
+		aggDraw.screen->setDrawTargetDims(0, w, h, w*aggDraw.screenBytesPerPixel);
 	if(aggDraw.hud)
 		aggDraw.hud->setDrawTargetDims((u8*)hudBuffer.data(), w, h, w*4);
 	if(aggDraw.lua)

--- a/desmume/src/frontend/modules/osd/agg/aggdraw.h
+++ b/desmume/src/frontend/modules/osd/agg/aggdraw.h
@@ -705,6 +705,7 @@ enum AggTarget
 class AggDraw_Desmume : public AggDraw
 {
 public:
+	AggDraw_Desmume();
 	void setTarget(AggTarget newTarget);
 	//void composite(void* dest);
 

--- a/desmume/src/frontend/modules/osd/agg/aggdraw.h
+++ b/desmume/src/frontend/modules/osd/agg/aggdraw.h
@@ -242,6 +242,8 @@ public:
 	bool empty;
 
 	virtual void clear() = 0;
+	
+	virtual void setDrawTargetDims(agg::int8u* buf, int width, int height, int stride) = 0;
 
 	virtual agg::rendering_buffer & buf() = 0;
 
@@ -408,6 +410,9 @@ public:
     virtual Agg2DBase::ImageResample imageResample() = 0;
 	static const agg::int8u* lookupFont(const std::string& name);
 	virtual void setFont(const std::string& name) = 0;
+#ifdef AGG2D_USE_VECTORFONTS
+	virtual void setVectorFont(const std::string& fileName, int size, bool bold) = 0;
+#endif
 	virtual void renderText(double dstX, double dstY, const std::string& str) = 0;
 	virtual void renderTextDropshadowed(double dstX, double dstY, const std::string& str)
 	{
@@ -427,6 +432,29 @@ public:
 		lineColor(lineColorOld);
 		renderText(dstX,dstY,str);
 	}
+#ifdef AGG2D_USE_VECTORFONTS
+	virtual void renderVectorFontText(double dstX, double dstY, const std::string& str) = 0;
+	virtual void renderVectorFontTextDropshadowed(double dstX, double dstY, const std::string& str, int shadowOffset = 1)
+	{
+		AggColor lineColorOld = lineColor();
+		if(lineColorOld.r+lineColorOld.g+lineColorOld.b<192)
+			lineColor(255-lineColorOld.r,255-lineColorOld.g,255-lineColorOld.b);
+		else
+			lineColor(0,0,0);
+		fillColor(lineColor());
+		renderVectorFontText(dstX-shadowOffset,dstY-shadowOffset,str);
+		renderVectorFontText(dstX,dstY-shadowOffset,str);
+		renderVectorFontText(dstX+shadowOffset,dstY-shadowOffset,str);
+		renderVectorFontText(dstX-shadowOffset,dstY,str);
+		renderVectorFontText(dstX+shadowOffset,dstY,str);
+		renderVectorFontText(dstX-shadowOffset,dstY+shadowOffset,str);
+		renderVectorFontText(dstX,dstY+shadowOffset,str);
+		renderVectorFontText(dstX+shadowOffset,dstY+shadowOffset,str);
+		lineColor(lineColorOld);
+		fillColor(lineColor());
+		renderVectorFontText(dstX,dstY,str);
+	}
+#endif
 
 
 	// Auxiliary
@@ -457,6 +485,13 @@ public:
 			BASE::clearAll(0,0,0,0);
 			undirty();
 		}
+	}
+	
+	virtual void setDrawTargetDims(agg::int8u* buf, int width, int height, int stride)
+	{
+		BASE::attach(buf,width,height,stride);
+
+		BASE::viewport(0, 0, width-1, height-1, 0, 0, width-1, height-1, TAGG2D::Anisotropic);
 	}
 
 	virtual agg::rendering_buffer & buf() { dirty(); return BASE::buf(); } // buf() might not always require calling dirty()
@@ -578,6 +613,9 @@ public:
 	virtual void polyline(double* xy, int numPoints) {dirty(); BASE::polyline(xy, numPoints);};
 
 	virtual void setFont(const std::string& name) { BASE::font(lookupFont(name)); }
+#ifdef AGG2D_USE_VECTORFONTS
+	virtual void setVectorFont(const std::string& fileName, int size, bool bold) {BASE::font(fileName.c_str(), size, bold); }
+#endif
 	virtual void renderText(double dstX, double dstY, const std::string& str) { 
 		dirty(); 
 		int height = BASE::font()[0];
@@ -585,6 +623,13 @@ public:
 		int offset = height-base*2;
 		BASE::renderText(dstX, dstY + offset, str);
 	}
+#ifdef AGG2D_USE_VECTORFONTS
+	virtual void renderVectorFontText(double dstX, double dstY, const std::string& str) {
+		dirty();
+		BASE::flipText(true);
+		BASE::text(dstX, dstY + BASE::fontHeight(), str.c_str());
+	}
+#endif
 
     // Path commands
     virtual void resetPath() {BASE::resetPath();};
@@ -668,6 +713,7 @@ public:
 extern AggDraw_Desmume aggDraw;
 
 void Agg_init();
+void Agg_setCustomSize(int w, int h);
 
 struct font_type
 {

--- a/desmume/src/frontend/modules/osd/agg/aggdraw.h
+++ b/desmume/src/frontend/modules/osd/agg/aggdraw.h
@@ -709,6 +709,7 @@ public:
 	//void composite(void* dest);
 
 	AggDrawTarget *screen, *hud, *lua;
+	int screenBytesPerPixel;
 };
 
 extern AggDraw_Desmume aggDraw;

--- a/desmume/src/frontend/modules/osd/agg/aggdraw.h
+++ b/desmume/src/frontend/modules/osd/agg/aggdraw.h
@@ -434,8 +434,9 @@ public:
 	}
 #ifdef AGG2D_USE_VECTORFONTS
 	virtual void renderVectorFontText(double dstX, double dstY, const std::string& str) = 0;
-	virtual void renderVectorFontTextDropshadowed(double dstX, double dstY, const std::string& str, int shadowOffset = 1)
+	virtual void renderVectorFontTextDropshadowed(double dstX, double dstY, const std::string& str, double shadowOffset = 1.0)
 	{
+		shadowOffset*=0.5;
 		AggColor lineColorOld = lineColor();
 		if(lineColorOld.r+lineColorOld.g+lineColorOld.b<192)
 			lineColor(255-lineColorOld.r,255-lineColorOld.g,255-lineColorOld.b);

--- a/desmume/src/frontend/posix/gtk/config.cpp
+++ b/desmume/src/frontend/posix/gtk/config.cpp
@@ -97,6 +97,25 @@ void value<string>::save() {
 	g_key_file_set_string(this->mKeyFile, this->mSection.c_str(), this->mKey.c_str(), this->mData.c_str());
 }
 
+/* class value<vector<int> > */
+
+template<>
+void value<vector<int> >::load() {
+	gsize l;
+	int* val = g_key_file_get_integer_list(this->mKeyFile, this->mSection.c_str(), this->mKey.c_str(), &l, NULL);
+	if(val)
+	{
+		this->mData.resize(l);
+		std::copy(val, val+l, this->mData.begin());
+		g_free(val);
+	}
+}
+
+template<>
+void value<vector<int> >::save() {
+	g_key_file_set_integer_list(this->mKeyFile, this->mSection.c_str(), this->mKey.c_str(), this->mData.data(), this->mData.size());
+}
+
 /* class Config */
 
 Config::Config()

--- a/desmume/src/frontend/posix/gtk/config_opts.h
+++ b/desmume/src/frontend/posix/gtk/config_opts.h
@@ -49,6 +49,7 @@ OPT(hud_input, bool, false, HudDisplay, Input)
 OPT(hud_graphicalInput, bool, false, HudDisplay, GraphicalInput)
 OPT(hud_rtc, bool, false, HudDisplay, RTC)
 OPT(hud_mic, bool, false, HudDisplay, Mic)
+OPT(hud_layout, std::vector<int>, std::vector<int>(), HudDisplay, Layout)
 
 /* Config */
 OPT(fpslimiter, bool, true, Config, FpsLimiter)

--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -3086,6 +3086,10 @@ common_gtk_main(GApplication *app, gpointer user_data)
 
     /* Init the hud / osd stuff */
 #ifdef HAVE_LIBAGG
+	SDL_DisplayMode cur_mode;
+	if(!SDL_GetCurrentDisplayMode(0, &cur_mode))
+		aggDraw.screenBytesPerPixel = SDL_BYTESPERPIXEL(cur_mode.format);
+	
     Desmume_InitOnce();
     Hud.reset();
     osd = new OSDCLASS(-1);
@@ -3165,9 +3169,6 @@ common_gtk_main(GApplication *app, gpointer user_data)
 	else
 		osd->useVectorFonts=false;
 #endif
-	SDL_DisplayMode cur_mode;
-	if(!SDL_GetCurrentDisplayMode(0, &cur_mode))
-		aggDraw.screenBytesPerPixel = SDL_BYTESPERPIXEL(cur_mode.format);
 	Agg_setCustomSize(real_framebuffer_width, real_framebuffer_height*2);
 	osd->scale=gpu_scale_factor;
 	HudLoadLayout();

--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -3693,8 +3693,9 @@ common_gtk_main(GApplication *app, gpointer user_data)
 
 static void Teardown() {
     delete video;
-	
+#ifdef HAVE_LIBAGG
 	HudSaveLayout();
+#endif
 	config.save();
 	avout_x264.end();
 	avout_flac.end();

--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -3787,6 +3787,8 @@ int main (int argc, char *argv[])
 #ifdef HAVE_LIBAGG
   fontConfig = FcInitLoadConfigAndFonts();
   vectorFontFile = FindFontFile("mono", true);
+  if(!vectorFontFile.size())
+    vectorFontFile = FindFontFile("sans", true);
 #endif
   // The global menu screws up the window size...
   unsetenv("UBUNTU_MENUPROXY");

--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -31,6 +31,7 @@
 #include <SDL.h>
 #include <X11/Xlib.h>
 #include <vector>
+#include <fontconfig/fontconfig.h>
 
 #include "types.h"
 #include "firmware.h"
@@ -126,6 +127,15 @@ enum {
     SUB_BG_3,
     SUB_OBJ
 };
+
+#ifdef AGG2D_USE_VECTORFONTS
+#define VECTOR_FONT_BASE_SIZE 6
+#endif
+
+static FcConfig* fontConfig;
+static std::string vectorFontFile;
+
+static std::string FindFontFile(const char* fontName, bool bold);
 
 gboolean EmuLoop(gpointer data);
 
@@ -1449,7 +1459,7 @@ static void RedrawScreen() {
 		GPU->GetDisplayInfo().isCustomSizeRequested ? (u16*)(GPU->GetDisplayInfo().masterCustomBuffer) : GPU->GetDisplayInfo().masterNativeBuffer16,
 		(uint32_t *)video->GetSrcBufferPtr(), real_framebuffer_width * real_framebuffer_height * 2);
 #ifdef HAVE_LIBAGG
-	aggDraw.hud->attach((u8*)video->GetSrcBufferPtr(), real_framebuffer_width, real_framebuffer_height * 2, 1024 * gpu_scale_factor);
+	aggDraw.hud->setDrawTargetDims((u8*)video->GetSrcBufferPtr(), real_framebuffer_width, real_framebuffer_height * 2, real_framebuffer_width * 4);
 	osd->update();
 	DrawHUD();
 	osd->clear();
@@ -1471,33 +1481,33 @@ static gboolean rotoscaled_hudedit(gint x, gint y, gboolean start)
 		devX = x;
 		devY = y;
 		cairo_matrix_transform_point(&nds_screen.topscreen_matrix, &devX, &devY);
-		topX = devX;
-		topY = devY;
+		topX = devX * gpu_scale_factor;
+		topY = devY * gpu_scale_factor;
 	}
 
 	if (nds_screen.orientation != ORIENT_SINGLE || nds_screen.swap) {
 		devX = x;
 		devY = y;
 		cairo_matrix_transform_point(&nds_screen.touch_matrix, &devX, &devY);
-		botX = devX;
-		botY = devY;
+		botX = devX * gpu_scale_factor;
+		botY = devY * gpu_scale_factor;
 	}
 
-	if (topX >= 0 && topY >= 0 && topX < 256 && topY < 192) {
+	if (topX >= 0 && topY >= 0 && topX < real_framebuffer_width && topY < real_framebuffer_height) {
 		X = topX;
-		Y = topY + (nds_screen.swap ? 192 : 0);
+		Y = topY + (nds_screen.swap ? real_framebuffer_height : 0);
 		startScreen = 0;
-	} else if (botX >= 0 && botY >= 0 && botX < 256 && botY < 192) {
+	} else if (botX >= 0 && botY >= 0 && botX < real_framebuffer_width && botY < real_framebuffer_height) {
 		X = botX;
-		Y = botY + (nds_screen.swap ? 0 : 192);
+		Y = botY + (nds_screen.swap ? 0 : real_framebuffer_height);
 		startScreen = 1;
 	} else if (!start) {
 		if (startScreen == 0) {
-			X = CLAMP(topX, 0, 255);
-			Y = CLAMP(topY, 0, 191) + (nds_screen.swap ? 192 : 0);
+			X = CLAMP(topX, 0, real_framebuffer_width-1);
+			Y = CLAMP(topY, 0, real_framebuffer_height-1) + (nds_screen.swap ? real_framebuffer_height : 0);
 		} else {
-			X = CLAMP(botX, 0, 255);
-			Y = CLAMP(botY, 0, 191) + (nds_screen.swap ? 0 : 192);
+			X = CLAMP(botX, 0, real_framebuffer_width-1);
+			Y = CLAMP(botY, 0, real_framebuffer_height-1) + (nds_screen.swap ? 0 : real_framebuffer_height);
 		}
 	} else {
 		LOG("TopX=%d, TopY=%d, BotX=%d, BotY=%d\n", topX, topY, botX, botY);
@@ -2098,6 +2108,7 @@ static void GraphicsSettingsDialog(GSimpleAction *action, GVariant *parameter, g
 		default:
 			break;
 		}
+		double old_scale_factor = gpu_scale_factor;
 		gpu_scale_factor = gtk_spin_button_get_value(wGPUScale);
 		if(gpu_scale_factor < GPU_SCALE_FACTOR_MIN)
 			gpu_scale_factor = GPU_SCALE_FACTOR_MIN;
@@ -2109,6 +2120,20 @@ static void GraphicsSettingsDialog(GSimpleAction *action, GVariant *parameter, g
 		real_framebuffer_height = GPU_FRAMEBUFFER_NATIVE_HEIGHT * gpu_scale_factor;
 		GPU->SetCustomFramebufferSize(real_framebuffer_width, real_framebuffer_height);
 		video->SetSourceSize(real_framebuffer_width, real_framebuffer_height * 2);
+#ifdef HAVE_LIBAGG
+#ifdef AGG2D_USE_VECTORFONTS
+		if(vectorFontFile.size() > 0)
+		{
+			aggDraw.hud->setVectorFont(vectorFontFile, VECTOR_FONT_BASE_SIZE * gpu_scale_factor, true);
+			osd->useVectorFonts=true;
+		}
+		else
+			osd->useVectorFonts=false;
+#endif
+		Agg_setCustomSize(real_framebuffer_width, real_framebuffer_height*2);
+		osd->scale=gpu_scale_factor;
+		Hud.rescale(old_scale_factor, gpu_scale_factor);
+#endif
 		CommonSettings.GFX3D_Renderer_TextureDeposterize = config.textureDeposterize = gtk_toggle_button_get_active(wPosterize);
 		CommonSettings.GFX3D_Renderer_TextureSmoothing = config.textureSmoothing = gtk_toggle_button_get_active(wSmoothing);
 		CommonSettings.GFX3D_Renderer_TextureScalingFactor = config.textureUpscale = scale;
@@ -3067,6 +3092,20 @@ common_gtk_main(GApplication *app, gpointer user_data)
     g_printerr("Using %d threads for video filter.\n", CommonSettings.num_cores);
     GPU->SetCustomFramebufferSize(real_framebuffer_width, real_framebuffer_height);
     video = new VideoFilter(real_framebuffer_width, real_framebuffer_height * 2, VideoFilterTypeID_None, CommonSettings.num_cores);
+#ifdef HAVE_LIBAGG
+#ifdef AGG2D_USE_VECTORFONTS
+	if(vectorFontFile.size() > 0)
+	{
+		aggDraw.hud->setVectorFont(vectorFontFile, VECTOR_FONT_BASE_SIZE * gpu_scale_factor, true);
+		osd->useVectorFonts=true;
+	}
+	else
+		osd->useVectorFonts=false;
+#endif
+	Agg_setCustomSize(real_framebuffer_width, real_framebuffer_height*2);
+	osd->scale=gpu_scale_factor;
+	Hud.reset();
+#endif
 
     /* Fetch the main elements from the window */
     GtkBuilder *builder = gtk_builder_new_from_resource("/org/desmume/DeSmuME/main.ui");
@@ -3644,9 +3683,38 @@ handle_open(GApplication *application,
     common_gtk_main(application, user_data);
 }
 
+static std::string FindFontFile(const char* fontName, bool bold)
+{
+	std::string fontFile;
+	FcPattern* pat = FcNameParse((const FcChar8*)fontName);
+	if(bold)
+		FcPatternAddInteger(pat, FC_WEIGHT, FC_WEIGHT_BOLD);
+	FcConfigSubstitute(fontConfig, pat, FcMatchPattern);
+	FcDefaultSubstitute(pat);
+	
+	// find the font
+	FcResult res;
+	FcPattern* font = FcFontMatch(fontConfig, pat, &res);
+	if (font)
+	{
+		FcChar8* file = NULL;
+		if (FcPatternGetString(font, FC_FILE, 0, &file) == FcResultMatch)
+		{
+			// save the file to another std::string
+			fontFile = (char*)file;
+		}
+		FcPatternDestroy(font);
+	}
+	FcPatternDestroy(pat);
+	return fontFile;
+}
+
 int main (int argc, char *argv[])
 {
   configured_features my_config;
+  
+  fontConfig = FcInitLoadConfigAndFonts();
+  vectorFontFile = FindFontFile("mono", true);
 
   // The global menu screws up the window size...
   unsetenv("UBUNTU_MENUPROXY");

--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -31,7 +31,7 @@
 #include <SDL.h>
 #include <X11/Xlib.h>
 #include <vector>
-#ifdef HAVE_LIBAGG
+#ifdef AGG2D_USE_VECTORFONTS
 #include <fontconfig/fontconfig.h>
 #endif
 
@@ -130,10 +130,8 @@ enum {
     SUB_OBJ
 };
 
-#ifdef HAVE_LIBAGG
 #ifdef AGG2D_USE_VECTORFONTS
 #define VECTOR_FONT_BASE_SIZE 16
-#endif
 
 static FcConfig* fontConfig;
 static std::string vectorFontFile;
@@ -3167,6 +3165,9 @@ common_gtk_main(GApplication *app, gpointer user_data)
 	else
 		osd->useVectorFonts=false;
 #endif
+	SDL_DisplayMode cur_mode;
+	if(!SDL_GetCurrentDisplayMode(0, &cur_mode))
+		aggDraw.screenBytesPerPixel = SDL_BYTESPERPIXEL(cur_mode.format);
 	Agg_setCustomSize(real_framebuffer_width, real_framebuffer_height*2);
 	osd->scale=gpu_scale_factor;
 	HudLoadLayout();
@@ -3750,7 +3751,7 @@ handle_open(GApplication *application,
     common_gtk_main(application, user_data);
 }
 
-#ifdef HAVE_LIBAGG
+#ifdef AGG2D_USE_VECTORFONTS
 
 static std::string FindFontFile(const char* fontName, bool bold)
 {
@@ -3784,7 +3785,7 @@ int main (int argc, char *argv[])
 {
   configured_features my_config;
 
-#ifdef HAVE_LIBAGG
+#ifdef AGG2D_USE_VECTORFONTS
   fontConfig = FcInitLoadConfigAndFonts();
   vectorFontFile = FindFontFile("mono", true);
   if(!vectorFontFile.size())

--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -31,7 +31,9 @@
 #include <SDL.h>
 #include <X11/Xlib.h>
 #include <vector>
+#ifdef HAVE_LIBAGG
 #include <fontconfig/fontconfig.h>
+#endif
 
 #include "types.h"
 #include "firmware.h"
@@ -128,6 +130,7 @@ enum {
     SUB_OBJ
 };
 
+#ifdef HAVE_LIBAGG
 #ifdef AGG2D_USE_VECTORFONTS
 #define VECTOR_FONT_BASE_SIZE 16
 #endif
@@ -136,6 +139,7 @@ static FcConfig* fontConfig;
 static std::string vectorFontFile;
 
 static std::string FindFontFile(const char* fontName, bool bold);
+#endif
 
 gboolean EmuLoop(gpointer data);
 
@@ -200,6 +204,7 @@ static void HudLagCounter(GSimpleAction *action, GVariant *parameter, gpointer u
 static void HudRtc(GSimpleAction *action, GVariant *parameter, gpointer user_data);
 static void HudMic(GSimpleAction *action, GVariant *parameter, gpointer user_data);
 static void HudEditor(GSimpleAction *action, GVariant *parameter, gpointer user_data);
+static void HudResetLayout(GSimpleAction *action, GVariant *parameter, gpointer user_data);
 static void HudSaveLayout();
 static void HudLoadLayout();
 #endif
@@ -259,6 +264,7 @@ static const GActionEntry app_entries[] = {
     { "hud_rtc",        HudRtc,                 NULL, "false" },
     { "hud_mic",        HudMic,                 NULL, "false" },
     { "hud_editor",     HudEditor,              NULL, "false" },
+    { "hud_reset_layout", HudResetLayout},
 #endif
 
     // Config
@@ -2829,6 +2835,12 @@ HudMacro(HudRtc, HUD_DISPLAY_RTC)
 HudMacro(HudMic, HUD_DISPLAY_MIC)
 HudMacro(HudEditor, HUD_DISPLAY_EDITOR)
 
+static void HudResetLayout(GSimpleAction *action, GVariant *parameter, gpointer user_data)
+{
+	Hud.reset();
+	HudSaveLayout();
+}
+
 static void HudSaveCoordsToVector(HudCoordinates* pCoords, int* pDest)
 {
 	pDest[0]=pCoords->x;
@@ -3738,6 +3750,8 @@ handle_open(GApplication *application,
     common_gtk_main(application, user_data);
 }
 
+#ifdef HAVE_LIBAGG
+
 static std::string FindFontFile(const char* fontName, bool bold)
 {
 	std::string fontFile;
@@ -3764,13 +3778,16 @@ static std::string FindFontFile(const char* fontName, bool bold)
 	return fontFile;
 }
 
+#endif
+
 int main (int argc, char *argv[])
 {
   configured_features my_config;
-  
+
+#ifdef HAVE_LIBAGG
   fontConfig = FcInitLoadConfigAndFonts();
   vectorFontFile = FindFontFile("mono", true);
-
+#endif
   // The global menu screws up the window size...
   unsetenv("UBUNTU_MENUPROXY");
 

--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -2124,7 +2124,7 @@ static void GraphicsSettingsDialog(GSimpleAction *action, GVariant *parameter, g
 #ifdef AGG2D_USE_VECTORFONTS
 		if(vectorFontFile.size() > 0)
 		{
-			aggDraw.hud->setVectorFont(vectorFontFile, VECTOR_FONT_BASE_SIZE * gpu_scale_factor, true);
+			aggDraw.hud->setVectorFont(vectorFontFile, std::max(10.0f, VECTOR_FONT_BASE_SIZE * gpu_scale_factor), true);
 			osd->useVectorFonts=true;
 		}
 		else
@@ -3096,7 +3096,7 @@ common_gtk_main(GApplication *app, gpointer user_data)
 #ifdef AGG2D_USE_VECTORFONTS
 	if(vectorFontFile.size() > 0)
 	{
-		aggDraw.hud->setVectorFont(vectorFontFile, VECTOR_FONT_BASE_SIZE * gpu_scale_factor, true);
+		aggDraw.hud->setVectorFont(vectorFontFile, std::max(10.0f, VECTOR_FONT_BASE_SIZE * gpu_scale_factor), true);
 		osd->useVectorFonts=true;
 	}
 	else

--- a/desmume/src/frontend/posix/gtk/menu.ui
+++ b/desmume/src/frontend/posix/gtk/menu.ui
@@ -834,6 +834,10 @@
         <attribute name='label' translatable='yes'>_Editor mode</attribute>
         <attribute name='action'>app.hud_editor</attribute>
       </item>
+      <item>
+        <attribute name='label' translatable='yes'>Reset layout</attribute>
+        <attribute name='action'>app.hud_reset_layout</attribute>
+      </item>
     </section>
   </menu>
   <menu id='hud_unsupported'>

--- a/desmume/src/frontend/posix/gtk/meson.build
+++ b/desmume/src/frontend/posix/gtk/meson.build
@@ -1,7 +1,8 @@
 dep_gtk3 = dependency('gtk+-3.0', version: '>=3.24')
 dep_x11 = dependency('x11')
+dep_fontconfig = dependency('fontconfig')
 
-gtk_dependencies = dependencies + [dep_gtk3, dep_x11]
+gtk_dependencies = dependencies + [dep_gtk3, dep_x11, dep_fontconfig]
 
 gnome = import('gnome')
 

--- a/desmume/src/frontend/posix/gtk/meson.build
+++ b/desmume/src/frontend/posix/gtk/meson.build
@@ -3,11 +3,6 @@ dep_x11 = dependency('x11')
 
 gtk_dependencies = dependencies + [dep_gtk3, dep_x11]
 
-if dep_agg.found()
-  dep_fontconfig = dependency('fontconfig')
-  gtk_dependencies = gtk_dependencies + [dep_fontconfig]
-endif
-
 gnome = import('gnome')
 
 gresource = gnome.compile_resources(

--- a/desmume/src/frontend/posix/gtk/meson.build
+++ b/desmume/src/frontend/posix/gtk/meson.build
@@ -1,8 +1,12 @@
 dep_gtk3 = dependency('gtk+-3.0', version: '>=3.24')
 dep_x11 = dependency('x11')
-dep_fontconfig = dependency('fontconfig')
 
-gtk_dependencies = dependencies + [dep_gtk3, dep_x11, dep_fontconfig]
+gtk_dependencies = dependencies + [dep_gtk3, dep_x11]
+
+if dep_agg.found()
+  dep_fontconfig = dependency('fontconfig')
+  gtk_dependencies = gtk_dependencies + [dep_fontconfig]
+endif
 
 gnome = import('gnome')
 

--- a/desmume/src/frontend/posix/meson.build
+++ b/desmume/src/frontend/posix/meson.build
@@ -10,6 +10,8 @@ project('desmume',
   license: 'GPL2+',
 )
 
+add_global_arguments('-DHOST_LINUX', language: ['c', 'cpp'])
+
 dep_glib2 = dependency('glib-2.0')
 dep_sdl = dependency('sdl2')
 dep_pcap = dependency('pcap')
@@ -203,6 +205,10 @@ endif
 if dep_agg.found()
   dependencies += dep_agg
   add_global_arguments('-DHAVE_LIBAGG', language: ['c', 'cpp'])
+  if get_option('frontend-gtk')
+    add_global_arguments('-DAGG2D_USE_VECTORFONTS', language: ['c', 'cpp'])
+    add_global_link_arguments('-laggfontfreetype', language: ['c', 'cpp'])
+  endif
   libdesmume_src += [
     '../modules/osd/agg/aggdraw.cpp',
     '../modules/osd/agg/agg_osd.cpp',

--- a/desmume/src/frontend/posix/meson.build
+++ b/desmume/src/frontend/posix/meson.build
@@ -10,8 +10,6 @@ project('desmume',
   license: 'GPL2+',
 )
 
-add_global_arguments('-DHOST_LINUX', language: ['c', 'cpp'])
-
 dep_glib2 = dependency('glib-2.0')
 dep_sdl = dependency('sdl2')
 dep_pcap = dependency('pcap')
@@ -22,6 +20,7 @@ dep_openal = dependency('openal', required: get_option('openal'))
 dep_alsa = dependency('alsa', required: false)
 dep_soundtouch = dependency('soundtouch', required: false)
 dep_agg = dependency('libagg', required: false)
+dep_fontconfig = dependency('fontconfig', required: false)
 
 # XXX: something wrong with this one.
 #dep_lua = dependency('lua-5.1', required: false)
@@ -205,7 +204,8 @@ endif
 if dep_agg.found()
   dependencies += dep_agg
   add_global_arguments('-DHAVE_LIBAGG', language: ['c', 'cpp'])
-  if get_option('frontend-gtk')
+  if dep_fontconfig.found()
+    dependencies += dep_fontconfig
     add_global_arguments('-DAGG2D_USE_VECTORFONTS', language: ['c', 'cpp'])
     add_global_link_arguments('-laggfontfreetype', language: ['c', 'cpp'])
   endif


### PR DESCRIPTION
My previous PR (implement GPU scale factor for GTK) created a problem with OSD: it is drawn without scaling, so when scale factor is > 1, OSD becomes small. I implemented OSD scaling. Scaling most elements like rectangles and ellipses seems trivial, but I could not figure out how to scale raster fonts. So instead I used vector fonts. Most of the code to work with vector fonts was already in AGG OSD files, I only added some missing functions and made using vector fonts optional via flag. By default vector fonts are disabled to keep other frontends working as before. It is frontend's job to provide a font file and set this flag. In GTK frontend I use fontconfig to locate monospace font file in the system. Also for vector fonts I could not figure out how to set background, so I made outlines instead.

Things to do:
Properly save OSD layout upon editing, restore on start.

Screenshot with OSD rendered at 4x:
![scaled_osd_screenshot](https://github.com/TASEmulators/desmume/assets/4952491/44a9cad4-8a71-4dd9-8f3d-0638c1c90ea2)
