### PR TITLE
libretro-common: fix implicit declarations

### DIFF
--- a/desmume/src/libretro-common/file/file_path.c
+++ b/desmume/src/libretro-common/file/file_path.c
@@ -20,6 +20,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#define _XOPEN_SOURCE 500   /* For strdup, realpath */
+
 #include <stdlib.h>
 #include <boolean.h>
 #include <string.h>


### PR DESCRIPTION
strdup and realpath are only declared by glibc's headers if _XOPEN_SOURCE >= 500.

(I checked libretro-common upstream, and this doesn't seem to have been fixed there; maybe they're not building with -std=c99 or similar. Previously it would just have produced a warning but an implicit declaration is a hard error with GCC 14.)