### PR TITLE
libretro-common: get strlcpy declarations on macOS

### DIFF
--- a/desmume/src/libretro-common/file/file_path.c
+++ b/desmume/src/libretro-common/file/file_path.c
@@ -20,7 +20,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#ifdef __MACH__
+#define _DARWIN_C_SOURCE    /* As below, plus strl* functions */
+#else
 #define _XOPEN_SOURCE 500   /* For strdup, realpath */
+#endif
 
 #include <stdlib.h>
 #include <boolean.h>


### PR DESCRIPTION
Defining _XOPEN_SOURCE here disabled the BSD extended string functions on macOS. Define _DARWIN_C_SOURCE instead on that platform.

(Please let the tests finish on this before merging - I don't have a macOS machine to test locally...)