### PR TITLE
[WiP] GTK: add OpenGL ES support

### DIFF
--- a/desmume/src/frontend/posix/gtk/graphics.ui
+++ b/desmume/src/frontend/posix/gtk/graphics.ui
@@ -65,6 +65,7 @@
                   <item translatable="yes">Null</item>
                   <item translatable="yes">SoftRasterizer</item>
                   <item translatable="yes">OpenGL</item>
+				  <item translatable="yes">OpenGL ES</item>
                 </items>
               </object>
               <packing>

--- a/desmume/src/frontend/posix/gtk/graphics.ui
+++ b/desmume/src/frontend/posix/gtk/graphics.ui
@@ -65,7 +65,7 @@
                   <item translatable="yes">Null</item>
                   <item translatable="yes">SoftRasterizer</item>
                   <item translatable="yes">OpenGL</item>
-				  <item translatable="yes">OpenGL ES</item>
+                  <item translatable="yes">OpenGL ES</item>
                 </items>
               </object>
               <packing>

--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -433,6 +433,9 @@ fill_configured_features( class configured_features *config,
 #ifdef HAVE_OPENGL
         "\t\t\t\t  2 = opengl\n"
 #endif
+#ifdef HAVE_GLES3
+        "\t\t\t\t  3 = gles\n"
+#endif
         ,"ENGINE"},
     { "save-type", 0, 0, G_OPTION_ARG_INT, &config->savetype, "Select savetype from the following:\n"
     "\t\t\t\t  0 = Autodetect (default)\n"
@@ -477,10 +480,16 @@ fill_configured_features( class configured_features *config,
 #ifdef HAVE_OPENGL
 				&& config->engine_3d != 2
 #endif
+#ifdef HAVE_GLES3
+				&& config->engine_3d != 3
+#endif
 						) {
 			g_printerr("Currently available ENGINES: 0, 1"
 #ifdef HAVE_OPENGL
 							", 2"
+#endif
+#ifdef HAVE_GLES3
+							", 3"
 #endif
 					"\n");
 			goto error;
@@ -2256,7 +2265,7 @@ static void GraphicsSettingsDialog(GSimpleAction *action, GVariant *parameter, g
 	// 3D Texture Smoothing
 	gtk_toggle_button_set_active(wSmoothing, CommonSettings.GFX3D_Renderer_TextureSmoothing);
 
-#ifdef HAVE_OPENGL
+#if defined(HAVE_OPENGL) || defined(HAVE_GLES3)
 	// OpenGL Multisample
 	int currentMultisample = CommonSettings.GFX3D_Renderer_MultisampleSize;
 	int currentActive = 0;
@@ -2351,7 +2360,7 @@ static void GraphicsSettingsDialog(GSimpleAction *action, GVariant *parameter, g
 		CommonSettings.GFX3D_Renderer_TextureSmoothing = config.textureSmoothing = gtk_toggle_button_get_active(wSmoothing);
 		CommonSettings.GFX3D_Renderer_TextureScalingFactor = config.textureUpscale = scale;
 		CommonSettings.GFX3D_HighResolutionInterpolateColor = config.highColorInterpolation = gtk_toggle_button_get_active(wHCInterpolate);
-#ifdef HAVE_OPENGL
+#if defined(HAVE_OPENGL) || defined(HAVE_GLES3)
 		int selectedMultisample = gtk_combo_box_get_active(wMultisample);
 		config.multisamplingSize = multisampleSizes[selectedMultisample];
 		config.multisampling = selectedMultisample != 0;

--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -2291,7 +2291,7 @@ static void GraphicsSettingsDialog(GSimpleAction *action, GVariant *parameter, g
 #else
 				if (!is_sdl_initialized())
 				{
-					init_sdl_3Demu();
+					init_sdl_3Demu(sel3DCore==3);
 				}
 #endif
 			}
@@ -3863,7 +3863,7 @@ common_gtk_main(GApplication *app, gpointer user_data)
 #else
 		if (!is_sdl_initialized())
 		{
-			init_sdl_3Demu();
+			init_sdl_3Demu(core==3);
 		}
 #endif
 	}

--- a/desmume/src/frontend/posix/gtk/sdl_3Demu.cpp
+++ b/desmume/src/frontend/posix/gtk/sdl_3Demu.cpp
@@ -50,7 +50,7 @@ bool deinit_sdl_3Demu(void)
     return ret;
 }
 
-bool init_sdl_3Demu(void) 
+bool init_sdl_3Demu(bool useES) 
 {
     SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
     SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
@@ -59,9 +59,18 @@ bool init_sdl_3Demu(void)
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
     SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
+    if(useES)
+    {
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+    }
+    else
+    {
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
+	}
 
     win = SDL_CreateWindow(NULL, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, real_framebuffer_width,
 						real_framebuffer_height, SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN);

--- a/desmume/src/frontend/posix/gtk/sdl_3Demu.h
+++ b/desmume/src/frontend/posix/gtk/sdl_3Demu.h
@@ -18,7 +18,7 @@
 #ifndef SDL_3DEMU_H
 #define SDL_3DEMU_H
 
-bool init_sdl_3Demu(void);
+bool init_sdl_3Demu(bool useES);
 bool deinit_sdl_3Demu(void);
 bool is_sdl_initialized(void);
 

--- a/desmume/src/frontend/posix/meson.build
+++ b/desmume/src/frontend/posix/meson.build
@@ -16,6 +16,7 @@ dep_pcap = dependency('pcap')
 dep_zlib = dependency('zlib')
 dep_threads = dependency('threads')
 dep_gl = dependency('gl', required: false)
+dep_gles3 = dependency('glesv2', required: false)
 dep_openal = dependency('openal', required: get_option('openal'))
 dep_alsa = dependency('alsa', required: false)
 dep_soundtouch = dependency('soundtouch', required: false)
@@ -173,6 +174,14 @@ if dep_gl.found()
   libdesmume_src += [
     '../../OGLRender.cpp',
     '../../OGLRender_3_2.cpp',
+  ]
+endif
+
+if dep_gles3.found()
+  dependencies += dep_gles3
+  add_global_arguments('-DHAVE_GLES3', language: ['c', 'cpp'])
+  libdesmume_src += [
+    '../../OGLRender_ES3.cpp',
   ]
 endif
 


### PR DESCRIPTION
Added support for GLES in posix/gtk frontend. Does not work for now, initialization fails with missing extension. See #812.