### PR TITLE
Fix OpenGL renderer init failure

### DIFF
--- a/desmume/src/OGLRender.cpp
+++ b/desmume/src/OGLRender.cpp
@@ -954,6 +954,12 @@ static Render3D* OpenGLRendererCreate()
 		INFO("OpenGL: oglrender_init is unassigned. Clients must assign this function pointer and have a working context before running OpenGL.\n");
 		return newRenderer;
 	}
+
+	if (!oglrender_init())
+	{
+		INFO("OpenGL: oglrender_init failed.\n");
+		return newRenderer;
+	}
 	
 	if (oglrender_beginOpenGL == NULL)
 	{
@@ -964,11 +970,6 @@ static Render3D* OpenGLRendererCreate()
 	if (oglrender_endOpenGL == NULL)
 	{
 		INFO("OpenGL: oglrender_endOpenGL is unassigned. Clients must assign this function pointer before running OpenGL.\n");
-		return newRenderer;
-	}
-	
-	if (!oglrender_init())
-	{
 		return newRenderer;
 	}
 	


### PR DESCRIPTION
(Regression from commit 76fe5f7. Fixes #815.)

`OpenGLRendererCreate()` checks if `oglrender_beginOpenGL` and `oglrender_endOpenGL` are assigned **before** running `oglrender_init()`. Issue is that they are **always** unassigned before `oglrender_init()` assigns them.   
Or at least that is the case on Windows.  
  
In essence this means that on boot this will always fail, resulting in a fallback to SoftRasterizer.  
Fix is simple enough, move the call to `oglrender_init()` up a few lines to make sure that both are assigned.  
  
Windows (now fixed):
```
DeSmuME 0.9.14 git#bd1f9887 x64-JIT SSE2
- compiled: Jul 22 2024 22:03:50

DirectX Input:
   - gamecontrol successfully inited: Controller (Xbox One For Windows)
Microphone successfully inited.
DeSmuME 0.9.14 git#bd1f9887 x64-JIT SSE2
Attempting change to 3d core to: OpenGL 3.2
WGL OpenGL mode: hardware
OpenGL: Successfully created geometry shaders.
OpenGL: Successfully created postprocess shaders.
OpenGL: Successfully created FBOs.
OpenGL: Successfully created multisampled FBO.
OpenGL: Renderer initialized successfully (v3.2.0).
[ Driver Info -
    Version: 4.6.0 NVIDIA 560.70
    Vendor: NVIDIA Corporation
    Renderer: NVIDIA GeForce GTX 1060 6GB/PCIe/SSE2 ]
```
Xubuntu VM (worked fine before and still working fine):
```
CPU mode: Interpreter
Failed to set format: Invalid argument
Microphone init failed.
DeSmuME 0.9.14 git#0 x64-JIT SSE4.2+AVX2
Using 8 threads for video filter.
OGL/SDL Renderer has finished the initialization.
OpenGL: Successfully created geometry shaders.
OpenGL: Successfully created postprocess shaders.
OpenGL: Successfully created FBOs.
OpenGL: Successfully created multisampled FBO.
OpenGL: Renderer initialized successfully (v3.2.0).
[ Driver Info -
    Version: 4.1 (Core Profile) Mesa 24.0.9-0ubuntu0.1
    Vendor: VMware, Inc.
    Renderer: SVGA3D; build: RELEASE;  LLVM; ]
```