### PR TITLE
Windows Port: Fix empty defaults for path settings

### DIFF
--- a/desmume/src/path.cpp
+++ b/desmume/src/path.cpp
@@ -240,7 +240,7 @@ void PathInfo::ReadKeyW(char *pathToRead, const wchar_t *key)
 	if (wcscmp(wpath, key) == 0) {
 		//since the variables are all intialized in this file they all use MAX_PATH
 		char temppath[MAX_PATH];
-		temppath[0] = 0;
+		strcpy(temppath, wcstombs((std::wstring)wpath).c_str());
 		GetDefaultPath(temppath, wcstombs((std::wstring)key).c_str(), MAX_PATH);
 		wcscpy(wpath,mbstowcs((std::string)temppath).c_str());
 	}


### PR DESCRIPTION
(Regression from commit 3511e14. Fixes #817.)  
  
`ReadKey(...)`(old) and `ReadKeyW(...)`(new in 3511e14) behave differently in regards to how they call `GetDefaultPath(...)`.  
  
In `ReadKey(...)` the first parameter of `GetDefaultPath(...)` is the value that is read by `GetPrivateProfileString(...)`.  
In `ReadKeyW(...)` the first parameter of `GetDefaultPath(...)` is the variable `temppath` (an empty string).  
  
Fixed by copying the value read by `GetPrivateProfileStringW(...)` into `temppath` before calling `GetDefaultPath(...)`.  
  
Paths are now working as intended:  
![5754425_paths_fixed](https://github.com/user-attachments/assets/3b5168d2-e138-4ae2-982e-67ddf1d4e174)