### PR TITLE
Update org.desmume.DeSmuME.metainfo.xml

### DIFF
--- a/desmume/src/frontend/posix/gtk/org.desmume.DeSmuME.metainfo.xml
+++ b/desmume/src/frontend/posix/gtk/org.desmume.DeSmuME.metainfo.xml
@@ -30,7 +30,7 @@
   </screenshots>
 
   <releases>
-    <release version="0.9.11" date="2015-04-15"/>
+    <release version="0.9.13" date="2022-05-23"/>
   </releases>
 
   <content_rating type="oars-1.1"/>


### PR DESCRIPTION
the current flatpack version is commit 640a1fdd93ac935314ab2a69725d03abc0ba8a8b

was 2 years ago but is a 9.14 version