### PR TITLE
[Linux/GTK3] Some gamepad input rework

### DIFF
--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -115,6 +115,7 @@ int real_framebuffer_height = GPU_FRAMEBUFFER_NATIVE_HEIGHT;
 
 
 desmume::config::Config config;
+bool in_joy_config_mode = false;
 
 #ifdef GDB_STUB
 gdbstub_handle_t arm9_gdb_stub = NULL;
@@ -2075,6 +2076,63 @@ static void Edit_Controls(GSimpleAction *action, GVariant *parameter, gpointer u
 
 }
 
+static gboolean JoyKeyAcceptTimerFunc(gpointer data)
+{
+    if(!in_joy_config_mode)
+        return FALSE;
+    SDL_Event event;
+    u16 key;
+    bool done = FALSE;
+    while(SDL_PollEvent(&event) && !done)
+    {
+        switch(event.type)
+        {
+        case SDL_JOYBUTTONDOWN:
+            key = ((event.jbutton.which & 15) << 12) | JOY_BUTTON << 8 | (event.jbutton.button & 255);
+            done = TRUE;
+            break;
+        case SDL_JOYAXISMOTION:
+            if( ((u32)abs(event.jaxis.value) >> 14) != 0 )
+            {
+                key = ((event.jaxis.which & 15) << 12) | JOY_AXIS << 8 | ((event.jaxis.axis & 127) << 1);
+                if (event.jaxis.value > 0)
+                    key |= 1;
+                done = TRUE;
+            }
+            break;
+        case SDL_JOYHATMOTION:
+            if (event.jhat.value != SDL_HAT_CENTERED) {
+                key = ((event.jhat.which & 15) << 12) | JOY_HAT << 8 | ((event.jhat.hat & 63) << 2);
+                if ((event.jhat.value & SDL_HAT_UP) != 0)
+                    key |= JOY_HAT_UP;
+                else if ((event.jhat.value & SDL_HAT_RIGHT) != 0)
+                    key |= JOY_HAT_RIGHT;
+                else if ((event.jhat.value & SDL_HAT_DOWN) != 0)
+                    key |= JOY_HAT_DOWN;
+                else if ((event.jhat.value & SDL_HAT_LEFT) != 0)
+                    key |= JOY_HAT_LEFT;
+                done = TRUE;
+            }
+            break;
+        }
+    }
+    
+    if(done) {
+        struct modify_key_ctx *ctx = (struct modify_key_ctx*)data;
+        ctx->mk_key_chosen = key;
+        gchar* YouPressed = g_strdup_printf("You pressed : %d\nClick OK to keep this key.", ctx->mk_key_chosen);
+        gtk_label_set_text(GTK_LABEL(ctx->label), YouPressed);
+        g_free(YouPressed);
+        return FALSE;
+    }
+    return in_joy_config_mode;
+}
+
+static void JoyKeyAcceptTimerStart(GtkWidget *w, GdkEventFocus *e, struct modify_key_ctx *ctx)
+{
+    g_timeout_add(200, JoyKeyAcceptTimerFunc, ctx);
+}
+
 static void AcceptNewJoyKey(GtkWidget *w, GdkEventFocus *e, struct modify_key_ctx *ctx)
 {
     gchar *YouPressed;
@@ -2097,7 +2155,7 @@ static void Modify_JoyKey(GtkWidget* widget, gpointer data)
     Key = GPOINTER_TO_INT(data);
     /* Joypad keys start at 1 */
     ctx.key_id = Key+1;
-    ctx.mk_key_chosen = 0;
+    ctx.mk_key_chosen = Keypad_Temp[Key];
     Title = g_strdup_printf("Press \"%s\" key ...\n", key_names[Key]);
     mkDialog = gtk_dialog_new_with_buttons(Title,
         GTK_WINDOW(pWindow),
@@ -2111,7 +2169,9 @@ static void Modify_JoyKey(GtkWidget* widget, gpointer data)
     gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(mkDialog))), ctx.label, TRUE, FALSE, 0);
     gtk_widget_show_all(gtk_dialog_get_content_area(GTK_DIALOG(mkDialog)));
 
-    g_signal_connect(G_OBJECT(mkDialog), "focus_in_event", G_CALLBACK(AcceptNewJoyKey), &ctx);
+    in_joy_config_mode = true;
+    g_signal_connect(G_OBJECT(mkDialog), "focus_in_event", G_CALLBACK(JoyKeyAcceptTimerStart), &ctx);
+    JoyKeyAcceptTimerFunc(&ctx);
 	
     switch(gtk_dialog_run(GTK_DIALOG(mkDialog))) {
     case GTK_RESPONSE_OK:
@@ -2125,6 +2185,7 @@ static void Modify_JoyKey(GtkWidget* widget, gpointer data)
         ctx.mk_key_chosen = 0;
         break;
     }
+    in_joy_config_mode = false;
 
     gtk_widget_destroy(mkDialog);
 
@@ -2852,7 +2913,8 @@ gboolean EmuLoop(gpointer data)
 #endif
 
     /* Merge the joystick keys with the keyboard ones */
-    process_joystick_events(&keys_latch);
+    if(!in_joy_config_mode)
+        process_joystick_events(&keys_latch);
     /* Update! */
     update_keypad(keys_latch);
 

--- a/desmume/src/frontend/posix/gtk2/meson.build
+++ b/desmume/src/frontend/posix/gtk2/meson.build
@@ -1,7 +1,7 @@
-dep_gtk3 = dependency('gtk+-3.0')
+dep_gtk2 = dependency('gtk+-2.0')
 dep_x11 = dependency('x11')
 
-gtk_dependencies = dependencies + [dep_gtk3, dep_x11]
+gtk_dependencies = dependencies + [dep_gtk2, dep_x11]
 
 desmume_src = [
   '../shared/avout_flac.cpp',

--- a/desmume/src/frontend/posix/meson.build
+++ b/desmume/src/frontend/posix/meson.build
@@ -337,3 +337,6 @@ endif
 if get_option('frontend-gtk')
   subdir('gtk')
 endif
+if get_option('frontend-gtk2')
+  subdir('gtk2')
+endif

--- a/desmume/src/frontend/posix/meson_options.txt
+++ b/desmume/src/frontend/posix/meson_options.txt
@@ -31,7 +31,12 @@ option('openal',
 option('frontend-gtk',
   type: 'boolean',
   value: true,
-  description: 'Enable GTK frontend',
+  description: 'Enable GTK3 frontend',
+)
+option('frontend-gtk2',
+  type: 'boolean',
+  value: false,
+  description: 'Enable GTK2 frontend',
 )
 option('frontend-cli',
   type: 'boolean',

--- a/desmume/src/frontend/posix/shared/ctrlssdl.cpp
+++ b/desmume/src/frontend/posix/shared/ctrlssdl.cpp
@@ -66,21 +66,21 @@ const char *key_names[NB_KEYS] =
  
 /* Default joypad configuration */
 const u32 default_joypad_cfg[NB_KEYS] =
-  { 0x0201,  // A
-    0x0200,  // B
-    0x0205,  // select
-    0x0208,  // start
-    0x0001, // Right
-    0x0000, // Left
-    0x0002, // Up
-    0x0003, // Down
-    0x0207,  // R
-    0x0206,  // L
-    0x0204,  // X
-    0x0203,  // Y
+  { 0xFFFF,  // A
+    0xFFFF,  // B
+    0xFFFF,  // select
+    0xFFFF,  // start
+    0xFFFF, // Right
+    0xFFFF, // Left
+    0xFFFF, // Up
+    0xFFFF, // Down
+    0xFFFF,  // R
+    0xFFFF,  // L
+    0xFFFF,  // X
+    0xFFFF,  // Y
     0xFFFF, // DEBUG
     0xFFFF, // BOOST
-    0x0202, // Lid
+    0xFFFF, // Lid
   };
 
 /* Load default joystick and keyboard configurations */


### PR DESCRIPTION
1. Unbind gamepad keys by default. The default bindings may fit one gamepad model but work weirdly with another causing issues like #834
2. Use non-blocking method to obtain gamepad keys/axes during configuration to avoid visible emulator freeze and possible deadlock (see #843)