### PR TITLE
Linux/GTK3: add gamepad hotplug support

### DIFF
--- a/desmume/src/frontend/interface/interface.cpp
+++ b/desmume/src/frontend/interface/interface.cpp
@@ -546,7 +546,7 @@ EXPORTED void desmume_input_joy_uninit(void)
 
 EXPORTED u16 desmume_input_joy_number_connected(void)
 {
-    return nbr_joy;
+    return get_number_of_joysticks();
 }
 
 EXPORTED u16 desmume_input_joy_get_key(int index)

--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -2088,13 +2088,13 @@ static gboolean JoyKeyAcceptTimerFunc(gpointer data)
         switch(event.type)
         {
         case SDL_JOYBUTTONDOWN:
-            key = ((event.jbutton.which & 15) << 12) | JOY_BUTTON << 8 | (event.jbutton.button & 255);
+            key = ((get_joystick_number_by_id(event.jbutton.which) & 15) << 12) | JOY_BUTTON << 8 | (event.jbutton.button & 255);
             done = TRUE;
             break;
         case SDL_JOYAXISMOTION:
             if( ((u32)abs(event.jaxis.value) >> 14) != 0 )
             {
-                key = ((event.jaxis.which & 15) << 12) | JOY_AXIS << 8 | ((event.jaxis.axis & 127) << 1);
+                key = ((get_joystick_number_by_id(event.jaxis.which) & 15) << 12) | JOY_AXIS << 8 | ((event.jaxis.axis & 127) << 1);
                 if (event.jaxis.value > 0)
                     key |= 1;
                 done = TRUE;
@@ -2102,7 +2102,7 @@ static gboolean JoyKeyAcceptTimerFunc(gpointer data)
             break;
         case SDL_JOYHATMOTION:
             if (event.jhat.value != SDL_HAT_CENTERED) {
-                key = ((event.jhat.which & 15) << 12) | JOY_HAT << 8 | ((event.jhat.hat & 63) << 2);
+                key = ((get_joystick_number_by_id(event.jhat.which) & 15) << 12) | JOY_HAT << 8 | ((event.jhat.hat & 63) << 2);
                 if ((event.jhat.value & SDL_HAT_UP) != 0)
                     key |= JOY_HAT_UP;
                 else if ((event.jhat.value & SDL_HAT_RIGHT) != 0)
@@ -2113,6 +2113,9 @@ static gboolean JoyKeyAcceptTimerFunc(gpointer data)
                     key |= JOY_HAT_LEFT;
                 done = TRUE;
             }
+            break;
+        default:
+            do_process_joystick_device_events(&event);
             break;
         }
     }
@@ -3320,6 +3323,13 @@ static gboolean timeout_exit_cb(gpointer data)
     return FALSE;
 }
 
+static gboolean OutOfLoopJoyDeviceCheckTimerFunc(gpointer data)
+{
+    if(!regMainLoop && !in_joy_config_mode)
+        process_joystick_device_events();
+    return !regMainLoop;
+}
+
 static void
 common_gtk_main(GApplication *app, gpointer user_data)
 {
@@ -4118,6 +4128,7 @@ common_gtk_main(GApplication *app, gpointer user_data)
     video->SetFilterParameteri(VF_PARAM_SCANLINE_D, _scanline_filter_d);
 
 	RedrawScreen();
+	g_timeout_add(200, OutOfLoopJoyDeviceCheckTimerFunc, 0);
 }
 
 static void Teardown() {

--- a/desmume/src/frontend/posix/shared/ctrlssdl.cpp
+++ b/desmume/src/frontend/posix/shared/ctrlssdl.cpp
@@ -547,6 +547,15 @@ int get_joystick_number_by_id(SDL_JoystickID id)
   return -1;
 }
 
+int get_number_of_joysticks()
+{
+  int i, n=0;
+  for(i=0; i<MAX_JOYSTICKS; ++i)
+    if(open_joysticks[i].first)
+      ++n;
+  return n;
+}
+
 static u16 shift_pressed;
 
 void

--- a/desmume/src/frontend/posix/shared/ctrlssdl.cpp
+++ b/desmume/src/frontend/posix/shared/ctrlssdl.cpp
@@ -35,7 +35,6 @@ u32 joypad_cfg[NB_KEYS];
 
 static_assert(sizeof(keyboard_cfg) == sizeof(joypad_cfg), "");
 
-u16 nbr_joy;
 mouse_status mouse;
 static int fullscreen;
 
@@ -120,7 +119,7 @@ BOOL init_joy( void) {
   for(i=0; i<MAX_JOYSTICKS; ++i)
     open_joysticks[i]=std::make_pair((SDL_Joystick*)NULL, 0);
 
-  nbr_joy = std::min(SDL_NumJoysticks(), MAX_JOYSTICKS);
+  int nbr_joy = std::min(SDL_NumJoysticks(), MAX_JOYSTICKS);
 
   if ( nbr_joy > 0) {
     printf("Found %d joysticks\n", nbr_joy);
@@ -156,7 +155,6 @@ void uninit_joy( void)
     }
   }
   
-  nbr_joy = 0;
   SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
 }
 

--- a/desmume/src/frontend/posix/shared/ctrlssdl.h
+++ b/desmume/src/frontend/posix/shared/ctrlssdl.h
@@ -30,6 +30,8 @@
 
 #include "types.h"
 
+#define MAX_JOYSTICKS 16
+
 #define ADD_KEY(keypad,key) ( (keypad) |= (key) )
 #define RM_KEY(keypad,key) ( (keypad) &= ~(key) )
 #define KEYMASK_(k)	(1 << (k))

--- a/desmume/src/frontend/posix/shared/ctrlssdl.h
+++ b/desmume/src/frontend/posix/shared/ctrlssdl.h
@@ -111,5 +111,11 @@ process_ctrls_event( SDL_Event& event,
 
 void
 process_joystick_events( u16 *keypad);
+int
+do_process_joystick_device_events(SDL_Event* event);
+void
+process_joystick_device_events();
+
+int get_joystick_number_by_id(SDL_JoystickID id);
 
 #endif /* CTRLSSDL_H */

--- a/desmume/src/frontend/posix/shared/ctrlssdl.h
+++ b/desmume/src/frontend/posix/shared/ctrlssdl.h
@@ -69,8 +69,6 @@ extern const char *key_names[NB_KEYS];
 extern u32 keyboard_cfg[NB_KEYS];
 /* Current joypad configuration */
 extern u32 joypad_cfg[NB_KEYS];
-/* Number of detected joypads */
-extern u16 nbr_joy;
 
 #ifndef GTK_UI
 struct mouse_status

--- a/desmume/src/frontend/posix/shared/ctrlssdl.h
+++ b/desmume/src/frontend/posix/shared/ctrlssdl.h
@@ -119,5 +119,6 @@ void
 process_joystick_device_events();
 
 int get_joystick_number_by_id(SDL_JoystickID id);
+int get_number_of_joysticks();
 
 #endif /* CTRLSSDL_H */


### PR DESCRIPTION
Support for reconnecting gamepads and connecting new ones while desmume is already running. For that I added corresponding event processing to ctrlssdl, also modifying how connected joystick info is stored (and fixing joystick uninit in the process: previously open_joysticks array was allocated but never populated, but used in uninit function nevertheless), and how pressed button id is calculated (previously joystick instance id was used but it changes every time gamepad is reconnected, so now joystick index is used instead).
This can be backported to GTK2 but GTK2 is now ahead of my branch after recent commits, so please review this PR as it is for now.