### PR TITLE
fix: null-terminate versionSubstring in OGLGetDriverVersion

### DIFF
--- a/desmume/src/OGLRender.cpp
+++ b/desmume/src/OGLRender.cpp
@@ -733,7 +733,8 @@ static void OGLGetDriverVersion(const char *oglVersionString,
 	}
 	
 	// Copy the version substring and parse it.
-	char *versionSubstring = (char *)malloc(versionStringLength * sizeof(char));
+	char *versionSubstring = (char *)malloc((versionStringLength + 1) * sizeof(char));
+	versionSubstring[versionStringLength] = '\0';
 	strncpy(versionSubstring, versionStrStart, versionStringLength);
 	
 	unsigned int major = 0;


### PR DESCRIPTION
Found with Valgrind while cleaning up the Linux cheat menu code.

The length calculated for `versionSubstring` is the number of bytes in the substring, but that did not account for the null terminator necessary when putting the data in its own string allocation. Thus, the `sscanf` call could read outsize the allocation bound.

The fix is very simple: provide the extra byte necessary to store a null terminator and do so.