### PR TITLE
EGL: use eglGetPlatformDisplay if available

### DIFF
--- a/desmume/src/frontend/posix/shared/egl_3Demu.cpp
+++ b/desmume/src/frontend/posix/shared/egl_3Demu.cpp
@@ -45,8 +45,20 @@ static bool __egl_initOpenGL(const int requestedAPI, const int requestedProfile,
 
 	EGLint eglMajorVersion;
 	EGLint eglMinorVersion;
-
+	
+#ifdef EGL_VERSION_1_5
+	EGLAttrib attr[] = {EGL_NONE};
+	currDisplay = eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_EXT, EGL_DEFAULT_DISPLAY, attr);
+	if(currDisplay == EGL_NO_DISPLAY)
+		currDisplay = eglGetPlatformDisplay(EGL_PLATFORM_XCB_EXT, EGL_DEFAULT_DISPLAY, attr);
+#else
 	currDisplay = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+#endif
+	if(currDisplay == EGL_NO_DISPLAY)
+	{
+		puts("EGL: failed to obtain display handle");
+		return false;
+	}
 	if (eglInitialize(currDisplay, &eglMajorVersion, &eglMinorVersion) == EGL_FALSE)
 	{
 		puts("EGL: eglInitialize failed");

--- a/desmume/src/frontend/posix/shared/egl_3Demu.cpp
+++ b/desmume/src/frontend/posix/shared/egl_3Demu.cpp
@@ -46,14 +46,12 @@ static bool __egl_initOpenGL(const int requestedAPI, const int requestedProfile,
 	EGLint eglMajorVersion;
 	EGLint eglMinorVersion;
 	
-#ifdef EGL_VERSION_1_5
-	EGLAttrib attr[] = {EGL_NONE};
-	currDisplay = eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_EXT, EGL_DEFAULT_DISPLAY, attr);
+	EGLAttrib displayAttr[] = {EGL_NONE};
+	currDisplay = eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_EXT, EGL_DEFAULT_DISPLAY, displayAttr);
 	if(currDisplay == EGL_NO_DISPLAY)
-		currDisplay = eglGetPlatformDisplay(EGL_PLATFORM_XCB_EXT, EGL_DEFAULT_DISPLAY, attr);
-#else
-	currDisplay = eglGetDisplay(EGL_DEFAULT_DISPLAY);
-#endif
+		currDisplay = eglGetPlatformDisplay(EGL_PLATFORM_XCB_EXT, EGL_DEFAULT_DISPLAY, displayAttr);
+	if(currDisplay == EGL_NO_DISPLAY)
+		currDisplay = eglGetDisplay(EGL_DEFAULT_DISPLAY);
 	if(currDisplay == EGL_NO_DISPLAY)
 	{
 		puts("EGL: failed to obtain display handle");


### PR DESCRIPTION
To properly use prime render offload eglGetPlatformDisplay must be used instead of eglGetDisplay. It's available in EGL 1.5, so use it if available, fallback to eglGetDisplay if not. Helps #864.