### PR TITLE
Minor fixes for libnds v2.0.0 release

### DIFF
--- a/desmume/src/MMU.cpp
+++ b/desmume/src/MMU.cpp
@@ -3754,7 +3754,21 @@ void FASTCALL _MMU_ARM9_write08(u32 adr, u8 val)
 				case eng_3D_GXSTAT:
 					MMU_new.gxstat.write(8,adr,val);
 					break;
-					
+
+				case REG_IPCSYNC:
+				{
+					u16 ipcsync = T1ReadWord(MMU.MMU_MEM[ARMCPU_ARM9][0x40], 0x180);
+					ipcsync &= 0xFF00;
+					ipcsync |= (val & 0xFF);
+					MMU_IPCSync(ARMCPU_ARM9, ipcsync);
+				}
+				case REG_IPCSYNC+1:
+				{
+					u16 ipcsync = T1ReadWord(MMU.MMU_MEM[ARMCPU_ARM9][0x40], 0x180);
+					ipcsync &= 0x00FF;
+					ipcsync |= ((val & 0xFF) << 8);
+					MMU_IPCSync(ARMCPU_ARM9, ipcsync);
+				}
 				case REG_AUXSPICNT:
 				case REG_AUXSPICNT+1:
 					write_auxspicnt(ARMCPU_ARM9, 8, adr & 1, val);
@@ -5595,6 +5609,21 @@ void FASTCALL _MMU_ARM7_write08(u32 adr, u8 val)
 			case REG_TM3CNTL+0: case REG_TM3CNTL+1: case REG_TM3CNTL+2: case REG_TM3CNTL+3:
 				printf("Unsupported 8bit write to timer registers");
 				return;
+
+			case REG_IPCSYNC:
+			{
+				u16 ipcsync = T1ReadWord(MMU.MMU_MEM[ARMCPU_ARM7][0x40], 0x180);
+				ipcsync &= 0xFF00;
+				ipcsync |= (val & 0xFF);
+				MMU_IPCSync(ARMCPU_ARM7, ipcsync);
+			}
+			case REG_IPCSYNC+1:
+			{
+				u16 ipcsync = T1ReadWord(MMU.MMU_MEM[ARMCPU_ARM7][0x40], 0x180);
+				ipcsync &= 0x00FF;
+				ipcsync |= ((val & 0xFF) << 8);
+				MMU_IPCSync(ARMCPU_ARM7, ipcsync);
+			}
 
 			case REG_AUXSPIDATA:
 			{

--- a/desmume/src/cp15.cpp
+++ b/desmume/src/cp15.cpp
@@ -366,6 +366,13 @@ BOOL armcp15_moveCP2ARM(armcp15_t *armcp15, u32 * R, u8 CRn, u8 CRm, u8 opcode1,
 			}
 		}
 		return FALSE;
+	case 13:
+		if(opcode1 == 0 && opcode2 == 1)
+		{
+			*R = armcp15->processID;
+			return TRUE;
+		}
+		return FALSE;
 	default:
 		LOG("Unsupported CP15 operation : MRC\n");
 		return FALSE;
@@ -486,6 +493,13 @@ BOOL armcp15_moveARM2CP(armcp15_t *armcp15, u32 val, u8 CRn, u8 CRm, u8 opcode1,
 					return FALSE;
 				}
 			}
+		}
+		return FALSE;
+	case 13:
+		if(opcode1 == 0 && opcode2 == 1)
+		{
+			armcp15->processID = val;
+			return TRUE;
 		}
 		return FALSE;
 	default:


### PR DESCRIPTION
libnds is now using two unimplemented functions internally:
- 8 bit writes to IPC sync (8 bit read is already implemented by the default case)
- Trace Process ID CP15 register (c13)

These are needed to avoid an infinite loop on newly compiled homebrew applications going forward.

Note I'm not sure if I implemented c13 properly; it seemed to be that the intention for the `processID` variable was for this exact register, but I may be wrong and a new variable may require being created.