### PR TITLE
Bugfix: MemROMReaderWrite not working for size=1

### DIFF
--- a/desmume/src/ROMReader.cpp
+++ b/desmume/src/ROMReader.cpp
@@ -348,7 +348,7 @@ int MemROMReaderWrite(void * file, void * buffer, u32 size)
 	if(remain<todo)
 		todo = remain;
 
-	if(todo==1) *(u8*)buffer = ((u8*)mem.buf)[mem.pos];
+	if (todo == 1) ((u8*)mem.buf)[mem.pos] = *(u8*)buffer;
 	else memcpy((u8*)mem.buf + mem.pos,buffer, todo);
 	mem.pos += todo;
 	return todo;


### PR DESCRIPTION
MemROMReaderWrite was not working for 1 byte length because it would copy the current mem's byte into the source buffer instead of copying source to mem.