### PR TITLE
fix movie command flags not actually being OR'd together

### DIFF
--- a/desmume/src/movie.cpp
+++ b/desmume/src/movie.cpp
@@ -1429,11 +1429,11 @@ void DesmumeInputToReplayRec(const UserInput &inInput, MovieRecord &outRecord)
 	                ((inInput.buttons.E) ? (1 <<  1) : 0);
 	
 	if (inInput.buttons.F)
-		outRecord.commands = MOVIECMD_LID;
+		outRecord.commands |= MOVIECMD_LID;
 	
 	if (movie_reset_command)
 	{
-		outRecord.commands = MOVIECMD_RESET;
+		outRecord.commands |= MOVIECMD_RESET;
 		movie_reset_command = false;
 	}
 	
@@ -1443,5 +1443,5 @@ void DesmumeInputToReplayRec(const UserInput &inInput, MovieRecord &outRecord)
 	outRecord.touch.micsample = MicSampleSelection;
 	
 	if (inInput.mic.micButtonPressed != 0)
-		outRecord.commands = MOVIECMD_MIC;
+		outRecord.commands |= MOVIECMD_MIC;
 }


### PR DESCRIPTION
This can be easily testing by pressing the lid toggle button, pressing and holding the mic hotkey and pressing the lid toggle button again.

Previously, this would write `MOVIECMD_MIC` as command instead of ORing it together with the `MOVIECMD_LID`, resulting in a desync when playing back the movie as the second lid toggle would be missing.