### PR TITLE
Linux/GTK: add support for gamepad touchpad -> touch screen input

### DIFF
--- a/desmume/src/frontend/posix/cli/main.cpp
+++ b/desmume/src/frontend/posix/cli/main.cpp
@@ -493,7 +493,7 @@ int main(int argc, char ** argv) {
       fprintf(stderr, "Warning: X11 not thread-safe\n");
     }
 
-  if(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER) == -1)
+  if(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | SDL_INIT_JOYSTICK| SDL_INIT_GAMECONTROLLER) == -1)
     {
       fprintf(stderr, "Error trying to initialize SDL: %s\n",
               SDL_GetError());

--- a/desmume/src/frontend/posix/gtk/main.cpp
+++ b/desmume/src/frontend/posix/gtk/main.cpp
@@ -2086,48 +2086,11 @@ static gboolean JoyKeyAcceptTimerFunc(gpointer data)
 {
     if(!in_joy_config_mode)
         return FALSE;
-    SDL_Event event;
-    u16 key;
-    bool done = FALSE;
-    while(SDL_PollEvent(&event) && !done)
-    {
-        switch(event.type)
-        {
-        case SDL_JOYBUTTONDOWN:
-            key = ((get_joystick_number_by_id(event.jbutton.which) & 15) << 12) | JOY_BUTTON << 8 | (event.jbutton.button & 255);
-            done = TRUE;
-            break;
-        case SDL_JOYAXISMOTION:
-            if( ((u32)abs(event.jaxis.value) >> 14) != 0 )
-            {
-                key = ((get_joystick_number_by_id(event.jaxis.which) & 15) << 12) | JOY_AXIS << 8 | ((event.jaxis.axis & 127) << 1);
-                if (event.jaxis.value > 0)
-                    key |= 1;
-                done = TRUE;
-            }
-            break;
-        case SDL_JOYHATMOTION:
-            if (event.jhat.value != SDL_HAT_CENTERED) {
-                key = ((get_joystick_number_by_id(event.jhat.which) & 15) << 12) | JOY_HAT << 8 | ((event.jhat.hat & 63) << 2);
-                if ((event.jhat.value & SDL_HAT_UP) != 0)
-                    key |= JOY_HAT_UP;
-                else if ((event.jhat.value & SDL_HAT_RIGHT) != 0)
-                    key |= JOY_HAT_RIGHT;
-                else if ((event.jhat.value & SDL_HAT_DOWN) != 0)
-                    key |= JOY_HAT_DOWN;
-                else if ((event.jhat.value & SDL_HAT_LEFT) != 0)
-                    key |= JOY_HAT_LEFT;
-                done = TRUE;
-            }
-            break;
-        default:
-            do_process_joystick_device_events(&event);
-            break;
-        }
-    }
-    
-    if(done) {
-        struct modify_key_ctx *ctx = (struct modify_key_ctx*)data;
+    struct modify_key_ctx *ctx = (struct modify_key_ctx*)data;
+    bool modified = FALSE;
+    u16 key=get_joy_key(ctx->key_id, &modified);
+    if(modified) {
+        
         ctx->mk_key_chosen = key;
         gchar* YouPressed = g_strdup_printf("You pressed : %d\nClick OK to keep this key.", ctx->mk_key_chosen);
         gtk_label_set_text(GTK_LABEL(ctx->label), YouPressed);
@@ -2926,6 +2889,16 @@ gboolean EmuLoop(gpointer data)
         process_joystick_events(&keys_latch);
     /* Update! */
     update_keypad(keys_latch);
+    /* Update mouse position and click (source - game controller touchpad)*/
+    if(touchpad.down) {
+        NDS_setTouchPos(touchpad.x * 256, touchpad.y * 192);
+        touchpad.down = 2;
+    }
+    if(touchpad.click)
+    {
+        NDS_releaseTouch();
+        touchpad.click = 0;
+    }
 
     desmume_cycle();    /* Emule ! */
 
@@ -3415,7 +3388,7 @@ common_gtk_main(GApplication *app, gpointer user_data)
     /* FIXME: SDL_INIT_VIDEO is needed for joystick support to work!?
      * Perhaps it needs a "window" to catch events...? */
     SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS,"1");
-    if(SDL_Init(SDL_INIT_TIMER|SDL_INIT_VIDEO) == -1) {
+    if(SDL_Init(SDL_INIT_TIMER|SDL_INIT_VIDEO|SDL_INIT_JOYSTICK|SDL_INIT_GAMECONTROLLER) == -1) {
         g_printerr("Error trying to initialize SDL: %s\n",
                     SDL_GetError());
         // TODO: return a non-zero exit status.

--- a/desmume/src/frontend/posix/shared/ctrlssdl.cpp
+++ b/desmume/src/frontend/posix/shared/ctrlssdl.cpp
@@ -144,7 +144,9 @@ BOOL init_joy( void) {
            printf("Touchpads: %d\n", SDL_GameControllerGetNumTouchpads(gcont));
            printf("%s\n", SDL_GameControllerHasSensor(gcont, SDL_SENSOR_ACCEL) ? "Accelerometer present" : "Accelerometer not present");
            printf("%s\n", SDL_GameControllerHasSensor(gcont, SDL_SENSOR_GYRO) ? "Gyroscope present" : "Gyroscope not present");
-           open_joysticks[i]={TRUE, {.gcont=gcont}, SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(gcont))};
+           open_joysticks[i].isController=TRUE;
+           open_joysticks[i].handle.gcont=gcont;
+           open_joysticks[i].id=SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(gcont));
          }
          else {
            fprintf(stderr, "Failed to open game controller %d: %s\n", i, SDL_GetError());
@@ -159,7 +161,9 @@ BOOL init_joy( void) {
            printf("Buttons: %d\n", SDL_JoystickNumButtons(joy));
            printf("Trackballs: %d\n", SDL_JoystickNumBalls(joy));
            printf("Hats: %d\n\n", SDL_JoystickNumHats(joy));
-           open_joysticks[i]={FALSE, {joy}, SDL_JoystickInstanceID(joy)};
+           open_joysticks[i].isController=FALSE;
+           open_joysticks[i].handle.joy=joy;
+           open_joysticks[i].id=SDL_JoystickInstanceID(joy);
          }
          else {
            fprintf(stderr, "Failed to open joystick %d: %s\n", i, SDL_GetError());
@@ -665,7 +669,9 @@ do_process_joystick_device_events(SDL_Event* event) {
               printf("Buttons: %d\n", SDL_JoystickNumButtons(joy));
               printf("Trackballs: %d\n", SDL_JoystickNumBalls(joy));
               printf("Hats: %d\n\n", SDL_JoystickNumHats(joy));
-              open_joysticks[event->jdevice.which]={FALSE, {joy}, SDL_JoystickInstanceID(joy)};
+              open_joysticks[event->cdevice.which].isController=FALSE;
+              open_joysticks[event->cdevice.which].handle.joy=joy;
+              open_joysticks[event->cdevice.which].id=SDL_JoystickInstanceID(joy);
             }
             else
               fprintf(stderr, "Failed to open joystick %d: %s\n", event->jdevice.which, SDL_GetError());
@@ -703,7 +709,9 @@ do_process_joystick_device_events(SDL_Event* event) {
               printf("Touchpads: %d\n", SDL_GameControllerGetNumTouchpads(gcont));
               printf("%s\n", SDL_GameControllerHasSensor(gcont, SDL_SENSOR_ACCEL) ? "Accelerometer present" : "Accelerometer not present");
               printf("%s\n", SDL_GameControllerHasSensor(gcont, SDL_SENSOR_GYRO) ? "Gyroscope present" : "Gyroscope not present");
-              open_joysticks[event->cdevice.which]={TRUE, {.gcont=gcont}, SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(gcont))};
+              open_joysticks[event->cdevice.which].isController=TRUE;
+              open_joysticks[event->cdevice.which].handle.gcont=gcont;
+              open_joysticks[event->cdevice.which].id=SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(gcont));
             }
             else
               fprintf(stderr, "Failed to open game controller %d: %s\n", event->cdevice.which, SDL_GetError());

--- a/desmume/src/frontend/posix/shared/ctrlssdl.cpp
+++ b/desmume/src/frontend/posix/shared/ctrlssdl.cpp
@@ -519,7 +519,11 @@ do_process_joystick_events( u16 *keypad, SDL_Event *event) {
       {
         if(event->ctouchpad.finger==0)
           if(!touchpad.down)
+          {
             touchpad.down=1;
+            touchpad.x=event->ctouchpad.x;
+            touchpad.y=event->ctouchpad.y;
+          }
       }
       break;
 
@@ -542,6 +546,8 @@ do_process_joystick_events( u16 *keypad, SDL_Event *event) {
           {
              touchpad.click = 1;
              if(touchpad.down > 1) touchpad.down = 0;
+             touchpad.x=event->ctouchpad.x;
+             touchpad.y=event->ctouchpad.y;
           }
       }
       break;

--- a/desmume/src/frontend/posix/shared/ctrlssdl.h
+++ b/desmume/src/frontend/posix/shared/ctrlssdl.h
@@ -82,6 +82,16 @@ struct mouse_status
 extern mouse_status mouse;
 #endif // !GTK_UI
 
+struct touchpad_status
+{
+  float x;
+  float y;
+  int down;
+  int click;
+};
+
+extern touchpad_status touchpad;
+
 struct ctrls_event_config {
   unsigned short keypad;
   float nds_screen_size_ratio;
@@ -98,7 +108,7 @@ struct ctrls_event_config {
 void load_default_config(const u32 kbCfg[]);
 BOOL init_joy( void);
 void uninit_joy( void);
-u16 get_joy_key(int index);
+u16 get_joy_key(int index, bool* modified=NULL);
 u16 get_set_joy_key(int index);
 void update_keypad(u16 keys);
 u16 get_keypad( void);

--- a/desmume/src/frontend/posix/shared/ctrlssdl.h
+++ b/desmume/src/frontend/posix/shared/ctrlssdl.h
@@ -92,6 +92,8 @@ struct touchpad_status
 
 extern touchpad_status touchpad;
 
+enum joystick_input_type {Joy_InvalidInput=-1, Joy_AxisMotion=0, Joy_HatMotion, Joy_ButtonDown, Joy_ButtonUp};
+
 struct ctrls_event_config {
   unsigned short keypad;
   float nds_screen_size_ratio;


### PR DESCRIPTION
For this I had to somewhat rework SDL input handling and add game controller api usage: if joystick is recognized as a game controller by SDL I open it as a game controller, otherwise fallback to generic joystick open. This is required to receive touchpad events. Additionally I have to filter out joystick events if joystick is open as game controller, otherwise there will be double events.

Touchpad finger coords are translated into touchscreen coords thus making touchpad act like touchscreen. This may be what is wanted in #897, but I implemented it only for Linux GTK frontends. Cli frontend must process changes in touchpad_status structure for touchpad translation to work (just like it does for mouse_status structure).

Note that hidraw access permissions are required to use touchpad, i.e. /dev/hidraw* file corresponding to gamepad must be accessible for user.